### PR TITLE
Various Gorilla audio backend fixes - Working SFX slider and more

### DIFF
--- a/Managers/AudioMan.cpp
+++ b/Managers/AudioMan.cpp
@@ -583,7 +583,7 @@ void AudioMan::PlayMusic(const char *filepath, int loops, double volumeOverride)
 		return;
 
 	strcpy(format, &filepath[dotPos + 1]);
-	
+
 	// Open the stream
 	m_pMusic = gau_create_handle_buffered_file(m_pMixer, m_pStreamManager, filepath, format, PlayNextCallback, 0, 0);
 	if (!m_pMusic)
@@ -1087,10 +1087,8 @@ bool AudioMan::SetSoundAttenuation(Sound *pSound, float distance)
 		//Mix_Volume(pSound->m_LastChannel, ((double)MIX_MAX_VOLUME * (1.0f - distance)));
 		Mix_SetDistance(pSound->m_LastChannel, (255 * distance));
 #elif __USE_SOUND_GORILLA
-		if (m_SoundChannels.size() > pSound->m_LastChannel)
-		{
+		if (pSound->m_LastChannel >= 0)
 			ga_handle_setParamf(m_SoundChannels[pSound->m_LastChannel], GA_HANDLE_PARAM_GAIN, m_SoundsVolume * (1.0f - distance));
-		}
 
 #endif
     }
@@ -1132,7 +1130,7 @@ bool AudioMan::SetSoundPitch(Sound *pSound, float pitch)
 #elif __USE_SOUND_SDLMIXER
 	// SDL seems to not support pitch changes
 #elif __USE_SOUND_GORILLA
-	if (pSound->m_AffectedByPitch && m_SoundChannels.size() > pSound->m_LastChannel)
+	if (pSound->m_AffectedByPitch && pSound->m_LastChannel >= 0)
 	{
 		m_PitchModifiers[pSound->m_LastChannel] = pitch;
 		ga_handle_setParamf(m_SoundChannels[pSound->m_LastChannel], GA_HANDLE_PARAM_PITCH, m_PitchModifiers[pSound->m_LastChannel] * m_GlobalPitch);


### PR DESCRIPTION
Title. This PR does the following to the Gorilla audio backend, which should hopefully bring it a few steps closer to parity with fmod.

- Makes the SFX slider work again. Gorilla doesn't seem to allow the developer to define a master volume. As such, the gain for each individual sound has to be set, so this PR makes the audio backend do that in PlaySound(), and makes sound attenuation base the gain value off of m_SoundsVolume rather than MAX_VOLUME (As otherwise, sounds affected by attenuation would be playing at 100% volume regardless of preferences). Fixes cortex-command-community/Cortex-Command-Community-Project-Source#14
- Indefinite loops (declared in RTE sound definitions as `LoopSetting = -1`) now function properly. This means dropship thruster noises now last for more than a second, among other things. This is done by making the m_Loops check if it's equal to 0 rather than if it's greater than 0, which makes it behave closer to how the fmod backend functions.
- SetSoundPitch now properly respects sounds that have m_AffectedByPitch set as false. This means that the main menu's noises are no longer affected by the global pitch, among other things.

There's still quite a few issues left to figure out, such as audio with lower bit rates (IE: The craft opening sound, jetpack loops, rocket thruster sounds.) refusing to play at all, and music refusing to loop. But! For now, this is at least a step forward.