### PR TITLE
Minimal Debug Configuration

### DIFF
--- a/Entities/ACDropShip.cpp
+++ b/Entities/ACDropShip.cpp
@@ -1184,7 +1184,7 @@ void ACDropShip::Draw(BITMAP *pTargetBitmap,
 
     if (mode == g_DrawColor)
     {
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
         acquire_bitmap(pTargetBitmap);
         putpixel(pTargetBitmap, floorf(m_Pos.m_X),
                               floorf(m_Pos.m_Y),
@@ -1196,7 +1196,7 @@ void ACDropShip::Draw(BITMAP *pTargetBitmap,
 
         m_pAtomGroup->Draw(pTargetBitmap, targetPos, false, 122);
 //        m_pDeepGroup->Draw(pTargetBitmap, targetPos, false, 13);
-#endif // _DEBUG
+#endif
     }
 }
 

--- a/Entities/ACRocket.cpp
+++ b/Entities/ACRocket.cpp
@@ -1252,7 +1252,7 @@ void ACRocket::Draw(BITMAP *pTargetBitmap,
         m_pCapsule->Draw(pTargetBitmap, targetPos, mode, onlyPhysical);
 */
     if (mode == g_DrawColor) {
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
         acquire_bitmap(pTargetBitmap);
         putpixel(pTargetBitmap, floorf(m_Pos.m_X),
                               floorf(m_Pos.m_Y),
@@ -1266,7 +1266,7 @@ void ACRocket::Draw(BITMAP *pTargetBitmap,
         m_pLFootGroup->Draw(pTargetBitmap, targetPos, true, 13);
 //        m_pAtomGroup->Draw(pTargetBitmap, targetPos, false, 122);
 //        m_pDeepGroup->Draw(pTargetBitmap, targetPos, false, 13);
-#endif // _DEBUG
+#endif
 //        m_pAtomGroup->Draw(pTargetBitmap, targetPos, false);
 //        m_pFGFootGroup->Draw(pTargetBitmap, targetPos, true);
 //        m_pBGFootGroup->Draw(pTargetBitmap, targetPos, true);

--- a/Entities/ACrab.cpp
+++ b/Entities/ACrab.cpp
@@ -3126,7 +3126,7 @@ void ACrab::Draw(BITMAP *pTargetBitmap,
     if (m_pLFGLeg)
         m_pLFGLeg->Draw(pTargetBitmap, targetPos, realMode, onlyPhysical);
 
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
 //    if (mode == g_DrawDebug)
     if (mode == g_DrawColor && !onlyPhysical)
     {
@@ -3145,7 +3145,7 @@ void ACrab::Draw(BITMAP *pTargetBitmap,
         m_pRFGFootGroup->Draw(pTargetBitmap, targetPos, true, 13);
         m_pRBGFootGroup->Draw(pTargetBitmap, targetPos, true, 13);
     }
-#endif // _DEBUG
+#endif
 }
 
 

--- a/Entities/AHuman.cpp
+++ b/Entities/AHuman.cpp
@@ -4726,7 +4726,7 @@ void AHuman::Draw(BITMAP *pTargetBitmap,
             m_pBGArm->DrawHand(pTargetBitmap, targetPos, realMode);
     }
     
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
     if (mode == g_DrawDebug)
     {
         // Limbpath debug drawing
@@ -4753,7 +4753,7 @@ void AHuman::Draw(BITMAP *pTargetBitmap,
         m_pFGHandGroup->Draw(pTargetBitmap, targetPos, true, 13);
         m_pBGHandGroup->Draw(pTargetBitmap, targetPos, true, 13);
     }
-#endif // _DEBUG
+#endif
 }
 
 
@@ -4782,7 +4782,7 @@ void AHuman::DrawHUD(BITMAP *pTargetBitmap, const Vector &targetPos, int whichSc
 
     Actor::DrawHUD(pTargetBitmap, targetPos, whichScreen);
 
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
     // Limbpath debug drawing
     m_Paths[FGROUND][WALK].Draw(pTargetBitmap, targetPos, 122);
     m_Paths[FGROUND][CRAWL].Draw(pTargetBitmap, targetPos, 122);
@@ -4813,7 +4813,7 @@ void AHuman::DrawHUD(BITMAP *pTargetBitmap, const Vector &targetPos, int whichSc
     // Raidus
 //    waypoint = m_Pos - targetPos;
 //    circle(pTargetBitmap, waypoint.m_X, waypoint.m_Y, m_MoveProximityLimit, g_RedColor);  
-#endif // _DEBUG
+#endif
 
     // Player AI drawing
 
@@ -5036,7 +5036,7 @@ void AHuman::DrawHUD(BITMAP *pTargetBitmap, const Vector &targetPos, int whichSc
     }
 
     // AI mode state debugging
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
 
     AllegroBitmap allegroBitmap(pTargetBitmap);
     Vector drawPos = m_Pos - targetPos;
@@ -5098,7 +5098,7 @@ void AHuman::DrawHUD(BITMAP *pTargetBitmap, const Vector &targetPos, int whichSc
     pSmallFont->DrawAligned(&allegroBitmap, drawPos.m_X + 2, drawPos.m_Y + m_HUDStack + 3, str, GUIFont::Centre);
     m_HUDStack += -9;
 
-#endif // _DEBUG
+#endif
 
 }
 

--- a/Entities/Actor.cpp
+++ b/Entities/Actor.cpp
@@ -1939,7 +1939,7 @@ void Actor::DrawHUD(BITMAP *pTargetBitmap, const Vector &targetPos, int whichScr
     }
 
     // AI mode state debugging
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
     AllegroBitmap bitmapInt(pTargetBitmap);
 
     // Obstacle state
@@ -1968,7 +1968,7 @@ void Actor::DrawHUD(BITMAP *pTargetBitmap, const Vector &targetPos, int whichScr
     pSmallFont->DrawAligned(&bitmapInt, drawPos.m_X + 2, drawPos.m_Y + m_HUDStack + 3, str, GUIFont::Centre);
     m_HUDStack += -9;
 
-#endif // _DEBUG
+#endif
 
     // Don't proceed to draw all the secret stuff below if this screen is for a player on the other team!
     if (g_ActivityMan.GetActivity() && g_ActivityMan.GetActivity()->GetTeamOfPlayer(whichScreen) != m_Team)

--- a/Entities/Arm.cpp
+++ b/Entities/Arm.cpp
@@ -651,13 +651,13 @@ void Arm::Draw(BITMAP *pTargetBitmap,
     if (m_pHeldMO && ((!m_pHeldMO->IsHeldDevice() && !m_pHeldMO->IsThrownDevice()) || m_pHeldMO->IsDrawnAfterParent()))
         m_pHeldMO->Draw(pTargetBitmap, targetPos, mode, onlyPhysical);
 /*
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
     if (m_PresetName == "Player BG Arm") {
         char str[64];
         sprintf(str, "m_Pos in draw: %f, %f", m_Pos.m_X, m_Pos.m_Y);
         g_FrameMan.DrawText(pTargetBitmap, str, m_Pos + Vector(4, -80), false);
     }
-#endif // _DEBUG
+#endif
 */
 }
 
@@ -684,13 +684,13 @@ void Arm::DrawHand(BITMAP *pTargetBitmap,
     else
         draw_sprite_h_flip(pTargetBitmap, m_pHand, handPos.m_X, handPos.m_Y);
 /*
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
     if (m_PresetName == "Player BG Arm") {
         char str[64];
         sprintf(str, "HandPos in hand draw: %f, %f", handPos.m_X, handPos.m_Y);
         g_FrameMan.DrawText(pTargetBitmap, str, handPos + Vector(4, -40), false);
     }
-#endif // _DEBUG
+#endif
 */
 }
 

--- a/Entities/Atom.cpp
+++ b/Entities/Atom.cpp
@@ -1212,7 +1212,7 @@ int Atom::Travel(float travelTime,
                 hitPos[Y] = intPos[Y];
                 ++hitCount;
 
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
                 if (m_TrailLength)
                     putpixel(pTrailBitmap, intPos[X], intPos[Y], 199);
 #endif

--- a/Entities/AtomGroup.cpp
+++ b/Entities/AtomGroup.cpp
@@ -1122,10 +1122,10 @@ float AtomGroup::Travel(Vector &position,
 //                        hitData.resImpulse[HITOR] = -hitData.hitVel[HITOR];
                 }
             }
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
             // Draw the positions of the atoms at the start of each segment, for visual debugging.
             putpixel(g_SceneMan.GetMOColorBitmap(), (*aItr)->GetCurrentPos().m_X, (*aItr)->GetCurrentPos().m_Y, 122);
-#endif //_DEBUG
+#endif
         }
 
         // Compute and scale the actual on-screen travel trajectory of the origin of thid AtomGroup
@@ -1252,13 +1252,13 @@ float AtomGroup::Travel(Vector &position,
 //                  else
 //                      DDTAbort("Atom reported hit to AtomGroup, but then reported neither MO or Terr hit!");
 
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
                     Vector tPos = (*aItr)->GetCurrentPos();
                     Vector tNorm = m_pOwnerMO->RotateOffset((*aItr)->GetNormal()) * 7;
                     line(g_SceneMan.GetMOColorBitmap(), tPos.m_X, tPos.m_Y, tPos.m_X + tNorm.m_X, tPos.m_Y + tNorm.m_Y, 244);
                     // Draw the positions of the hitpoints on screen for easy debugging.
 //                    putpixel(g_SceneMan.GetMOColorBitmap(), tPos.m_X, tPos.m_Y, 5);
-#endif //_DEBUG
+#endif
                 }
             }
 
@@ -1862,10 +1862,10 @@ before adding them to the MovableMan.
                                                                            intPos[Y] + rotatedOffset.m_Y))
                     hitTerrAtoms.push_back(pair<Atom *, Vector>(*aItr, rotatedOffset));
 /*
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
                 // Draw the positions of the hitpoints on screen for easy debugging.
                 putpixel(g_SceneMan.GetMOColorBitmap(), floorf(position.m_X + rotatedOffset.m_X), floorf(position.m_Y + rotatedOffset.m_Y), 122);
-#endif //_DEBUG
+#endif
 */
             }
 
@@ -2352,10 +2352,10 @@ bool AtomGroup::InTerrain()
         if (g_SceneMan.GetTerrMatter(aPos.m_X, aPos.m_Y) != g_MaterialAir)
             penetrates = true;
 /*
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
         // Draw a dot for each atom for visual reference.
         putpixel(g_SceneMan.GetDebugBitmap(), aPos.m_X, aPos.m_Y, 112);
-#endif //_DEBUG
+#endif
 */
     }
 

--- a/Entities/Attachable.cpp
+++ b/Entities/Attachable.cpp
@@ -297,7 +297,7 @@ void Attachable::Detach()
 	// Since it's no longer atteched it should belong to itself
 	m_RootMOID = m_MOID;
 
-#ifdef _DEBUG
+#if defined DEBUG_BUILD || defined MIN_DEBUG_BUILD
 	DAssert(m_RootMOID == g_NoMOID || (m_RootMOID >= 0 && m_RootMOID < g_MovableMan.GetMOIDCount()), "MOID out of bounds!");
 	DAssert(m_MOID == g_NoMOID || (m_MOID >= 0 && m_MOID < g_MovableMan.GetMOIDCount()), "MOID out of bounds!");
 #endif
@@ -660,13 +660,13 @@ void Attachable::Draw(BITMAP *pTargetBitmap,
     }
 */
 /*
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
         pTargetBitmap->Lock();
         pTargetBitmap->PutPixel(m_Pos.GetFloorIntX() - targetPos.m_X,
                               m_Pos.GetFloorIntY() - targetPos.m_Y,
                               64);
         pTargetBitmap->UnLock();
-#endif // _DEBUG
+#endif
 */
 }
 

--- a/Entities/HeldDevice.cpp
+++ b/Entities/HeldDevice.cpp
@@ -463,13 +463,13 @@ void HeldDevice::Draw(BITMAP *pTargetBitmap,
     }
 */
 /*
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
     if (mode == g_DrawColor && !onlyPhysical)
     {
         m_pAtomGroup->Draw(pTargetBitmap, targetPos, false, 122);
         m_pDeepGroup->Draw(pTargetBitmap, targetPos, false, 13);
     }
-#endif // _DEBUG
+#endif
 */
 }
 

--- a/Entities/MOSRotating.cpp
+++ b/Entities/MOSRotating.cpp
@@ -1611,7 +1611,7 @@ void MOSRotating::PostTravel()
 void MOSRotating::Update()
 {
 
-#ifdef _DEBUG
+#if defined DEBUG_BUILD || defined MIN_DEBUG_BUILD
 	DAssert(m_MOID == g_NoMOID || (m_MOID >= 0 && m_MOID < g_MovableMan.GetMOIDCount()), "MOID out of bounds!");
 #endif
 

--- a/Entities/MultiplayerServerLobby.cpp
+++ b/Entities/MultiplayerServerLobby.cpp
@@ -1116,13 +1116,13 @@ namespace RTE
 				m_pActivitySelect->AddItem(pActivity->GetPresetName(), "", 0, pActivity);
 
 				// Save the tutorial mission so we can select it by default
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
 				if (pActivity->GetPresetName() == "Network Test Activity")
 					skirmishIndex = index;
 #else
 				if (pActivity->GetPresetName() == "Skirmish Defense")
 					skirmishIndex = index;
-#endif // DEBUG
+#endif
 				index++;
 			}
 		}

--- a/Main.cpp
+++ b/Main.cpp
@@ -2735,10 +2735,10 @@ int main(int argc, char *argv[])
 	SteamAPI_Shutdown();
 #endif
 
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
     // Dump out the info about how well memory cleanup went
     Entity::ClassInfo::DumpPoolMemoryInfo(Writer("MemCleanupInfo.txt"));
-#endif // _DEBUG
+#endif
 
 #if defined(__APPLE__)
 	OsxUtil::Destroy();

--- a/Managers/ConsoleMan.cpp
+++ b/Managers/ConsoleMan.cpp
@@ -167,10 +167,8 @@ int ConsoleMan::Save(Writer &writer) const
 
 void ConsoleMan::Destroy()
 {
-//#ifdef _DEBUG
     // Dump out the text in the console
     SaveAllText("LogConsole.txt");
-//#endif // _DEBUG
 
     delete m_pGUIController;
     delete m_pGUIInput;

--- a/Managers/FrameMan.cpp
+++ b/Managers/FrameMan.cpp
@@ -2135,7 +2135,7 @@ void FrameMan::Draw()
         set_clip_state(pDrawScreen, 1);
 
 		//Always draw seam in debug mode
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
 		//DrawLinePrimitive(Vector(0,0),Vector(0,g_SceneMan.GetSceneHeight()), 5);
 #endif
 

--- a/Managers/MovableMan.cpp
+++ b/Managers/MovableMan.cpp
@@ -1140,14 +1140,14 @@ bool MovableMan::RemoveParticle(MovableObject *pMOToRem)
 
 bool MovableMan::ValidateMOIDs()
 {
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
     float test;
     for (vector<MovableObject *>::iterator itr = m_MOIDIndex.begin(); itr != m_MOIDIndex.end(); ++itr)
     {
         if (*itr)
             test = (*itr)->GetGoldValue();
     }
-#endif _DEBUG
+#endif
     return true;
 }
 
@@ -1776,11 +1776,6 @@ void MovableMan::Update()
             }
         }
 		g_FrameMan.StopPerformanceMeasurement(FrameMan::PERF_ACTORS_PASS2);
-
-    // TOD0: TEMP REMOVE!
-#ifdef _DEBUG
-//        ValidateMOIDs();
-#endif _DEBUG
 
         // Items
         {

--- a/Managers/NetworkClient.cpp
+++ b/Managers/NetworkClient.cpp
@@ -1398,10 +1398,10 @@ namespace RTE
 
 		// Input is sent at whetever settings are set in inputs per second
 		float ips = m_ClientInputFps;
-		#ifdef _DEBUG
+#if defined DEBUG_BUILD || defined MIN_DEBUG_BUILD
 		// Reduce input rate for debugging because it may overflow the input queue
 		ips = 10; 
-		#endif
+#endif
 
 		int64_t currentTicks = g_TimerMan.GetRealTickCount();
 

--- a/Managers/NetworkServer.cpp
+++ b/Managers/NetworkServer.cpp
@@ -70,10 +70,10 @@ namespace RTE
 		}
 		ns->SetThreadExitReason(player, NetworkServer::THREAD_FINISH);
 
-//#ifdef _DEBUG
+//#ifdef DEBUG_BUILD
 		// Not thread safe at all to do this, just for debugging purposes
 		//g_ConsoleMan.PrintString("Thread exited " + player);
-//#endif // _DEBUG
+//#endif
 
 	}
 

--- a/Managers/SceneMan.cpp
+++ b/Managers/SceneMan.cpp
@@ -246,7 +246,7 @@ int SceneMan::LoadScene(Scene *pNewScene, bool placeObjects, bool placeUnits)
     m_pMOIDLayer->Create(pBitmap, false, Vector(), m_pCurrentScene->WrapsX(), m_pCurrentScene->WrapsY(), Vector(1.0, 1.0));
     pBitmap = 0;
 
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
     // Create the Debug SceneLayer
     delete m_pDebugLayer;
     pBitmap = create_bitmap_ex(8, GetSceneWidth(), GetSceneHeight());
@@ -254,7 +254,7 @@ int SceneMan::LoadScene(Scene *pNewScene, bool placeObjects, bool placeUnits)
     m_pDebugLayer = new SceneLayer();
     m_pDebugLayer->Create(pBitmap, true, Vector(), m_pCurrentScene->WrapsX(), m_pCurrentScene->WrapsY(), Vector(1.0, 1.0));
     pBitmap = 0;
-#endif // _DEBUG
+#endif
 
     // Finally draw the ID:s of the MO:s to the MOID layers for the first time
     g_MovableMan.UpdateDrawMOIDs(m_pMOIDLayer->GetBitmap());
@@ -555,7 +555,7 @@ BITMAP * SceneMan::GetMOColorBitmap() const { return m_pMOColorLayer->GetBitmap(
 // Method:          GetDebugBitmap
 //////////////////////////////////////////////////////////////////////////////////////////
 // Description:     Gets the bitmap of the SceneLayer that debug graphics is drawn onto.
-//                  Will only return valid BITMAP if building with _DEBUG.
+//                  Will only return valid BITMAP if building with DEBUG_BUILD.
 
 BITMAP * SceneMan::GetDebugBitmap() const { return m_pDebugLayer->GetBitmap(); }
 
@@ -1642,10 +1642,10 @@ void SceneMan::RestoreUnseenBox(const int posX, const int posY, const int width,
 
 bool SceneMan::CastUnseenRay(int team, const Vector &start, const Vector &ray, Vector &endPos, int strengthLimit, int skip, bool reveal)
 {
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
     if (m_pDebugLayer)
         m_pDebugLayer->LockBitmaps();
-#endif //_DEBUG
+#endif
 
     if (!m_pCurrentScene->GetUnseenLayer(team))
         return false;
@@ -1741,18 +1741,18 @@ bool SceneMan::CastUnseenRay(int team, const Vector &start, const Vector &ray, V
             }
             // Reset skip counter
             skipped = 0;
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
             // Draw debug graphics, if applicable
             if (m_pDebugLayer)
                 m_pDebugLayer->SetPixel(intPos[X], intPos[Y], 13);
-#endif //_DEBUG
+#endif
         }
     }
 
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
     if (m_pDebugLayer)
         m_pDebugLayer->UnlockBitmaps();
-#endif //_DEBUG
+#endif
 
     return affectedAny;
 }
@@ -1791,10 +1791,10 @@ bool SceneMan::CastUnseeRay(int team, const Vector &start, const Vector &ray, Ve
 
 bool SceneMan::CastMaterialRay(const Vector &start, const Vector &ray, unsigned char material, Vector &result, int skip, bool wrap)
 {
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
     if (m_pDebugLayer)
         m_pDebugLayer->LockBitmaps();
-#endif //_DEBUG
+#endif
 
     int hitCount = 0, error, dom, sub, domSteps, skipped = skip;
     int intPos[2], delta[2], delta2[2], increment[2];
@@ -1876,18 +1876,18 @@ bool SceneMan::CastMaterialRay(const Vector &start, const Vector &ray, unsigned 
 
             skipped = 0;
 
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
             // Draw debug graphics, if applicable
             if (m_pDebugLayer)
                 m_pDebugLayer->SetPixel(intPos[X], intPos[Y], 13);
-#endif //_DEBUG
+#endif
         }
     }
 
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
     if (m_pDebugLayer)
         m_pDebugLayer->UnlockBitmaps();
-#endif //_DEBUG
+#endif
 
     return foundPixel;
 }
@@ -1922,10 +1922,10 @@ float SceneMan::CastMaterialRay(const Vector &start, const Vector &ray, unsigned
 
 bool SceneMan::CastNotMaterialRay(const Vector &start, const Vector &ray, unsigned char material, Vector &result, int skip, bool checkMOs)
 {
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
     if (m_pDebugLayer)
         m_pDebugLayer->LockBitmaps();
-#endif //_DEBUG
+#endif
 
     int hitCount = 0, error, dom, sub, domSteps, skipped = skip;
     int intPos[2], delta[2], delta2[2], increment[2];
@@ -2007,18 +2007,18 @@ bool SceneMan::CastNotMaterialRay(const Vector &start, const Vector &ray, unsign
             }
 
             skipped = 0;
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
             // Draw debug graphics, if applicable
             if (m_pDebugLayer)
                 m_pDebugLayer->SetPixel(intPos[X], intPos[Y], 13);
-#endif //_DEBUG
+#endif
         }
     }
 
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
     if (m_pDebugLayer)
         m_pDebugLayer->UnlockBitmaps();
-#endif //_DEBUG
+#endif
 
     return foundPixel;
 }
@@ -2242,10 +2242,10 @@ float SceneMan::CastMaxStrengthRay(const Vector &start, const Vector &end, int s
 
 bool SceneMan::CastStrengthRay(const Vector &start, const Vector &ray, float strength, Vector &result, int skip, unsigned char ignoreMaterial, bool wrap)
 {
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
     if (m_pDebugLayer)
         m_pDebugLayer->LockBitmaps();
-#endif //_DEBUG
+#endif
 
     int hitCount = 0, error, dom, sub, domSteps, skipped = skip;
     int intPos[2], delta[2], delta2[2], increment[2];
@@ -2336,18 +2336,18 @@ bool SceneMan::CastStrengthRay(const Vector &start, const Vector &ray, float str
             }
             skipped = 0;
 
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
             // Draw debug graphics, if applicable
             if (m_pDebugLayer)
                 m_pDebugLayer->SetPixel(intPos[X], intPos[Y], 13);
-#endif //_DEBUG
+#endif
         }
     }
 
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
     if (m_pDebugLayer)
         m_pDebugLayer->UnlockBitmaps();
-#endif //_DEBUG
+#endif
 
     // If no pixel of sufficient strength was found, set the result to the final tried position
     if (!foundPixel)
@@ -2366,10 +2366,10 @@ bool SceneMan::CastStrengthRay(const Vector &start, const Vector &ray, float str
 
 bool SceneMan::CastWeaknessRay(const Vector &start, const Vector &ray, float strength, Vector &result, int skip, bool wrap)
 {
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
     if (m_pDebugLayer)
         m_pDebugLayer->LockBitmaps();
-#endif //_DEBUG
+#endif
 
     int hitCount = 0, error, dom, sub, domSteps, skipped = skip;
     int intPos[2], delta[2], delta2[2], increment[2];
@@ -2456,18 +2456,18 @@ bool SceneMan::CastWeaknessRay(const Vector &start, const Vector &ray, float str
 
             skipped = 0;
 
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
             // Draw debug graphics, if applicable
             if (m_pDebugLayer)
                 m_pDebugLayer->SetPixel(intPos[X], intPos[Y], 13);
-#endif //_DEBUG
+#endif
         }
     }
 
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
     if (m_pDebugLayer)
         m_pDebugLayer->UnlockBitmaps();
-#endif //_DEBUG
+#endif
 
     // If no pixel of sufficient strength was found, set the result to the final tried position
     if (!foundPixel)
@@ -2486,10 +2486,10 @@ bool SceneMan::CastWeaknessRay(const Vector &start, const Vector &ray, float str
 
 MOID SceneMan::CastMORay(const Vector &start, const Vector &ray, MOID ignoreMOID, int ignoreTeam, unsigned char ignoreMaterial, bool ignoreAllTerrain, int skip)
 {
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
     if (m_pDebugLayer)
         m_pDebugLayer->LockBitmaps();
-#endif //_DEBUG
+#endif
 
     int hitCount = 0, error, dom, sub, domSteps, skipped = skip;
     int intPos[2], delta[2], delta2[2], increment[2];
@@ -2603,18 +2603,18 @@ MOID SceneMan::CastMORay(const Vector &start, const Vector &ray, MOID ignoreMOID
 
             skipped = 0;
 
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
             // Draw debug graphics, if applicable
             if (m_pDebugLayer)
                 m_pDebugLayer->SetPixel(intPos[X], intPos[Y], 120);
-#endif //_DEBUG
+#endif
         }
     }
 
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
     if (m_pDebugLayer)
         m_pDebugLayer->UnlockBitmaps();
-#endif //_DEBUG
+#endif
 
     // Didn't hit anything but air
     return g_NoMOID;
@@ -2628,10 +2628,10 @@ MOID SceneMan::CastMORay(const Vector &start, const Vector &ray, MOID ignoreMOID
 
 bool SceneMan::CastFindMORay(const Vector &start, const Vector &ray, MOID targetMOID, Vector &resultPos, unsigned char ignoreMaterial, bool ignoreAllTerrain, int skip)
 {
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
     if (m_pDebugLayer)
         m_pDebugLayer->LockBitmaps();
-#endif //_DEBUG
+#endif
 
     int hitCount = 0, error, dom, sub, domSteps, skipped = skip;;
     int intPos[2], delta[2], delta2[2], increment[2];
@@ -2725,18 +2725,18 @@ bool SceneMan::CastFindMORay(const Vector &start, const Vector &ray, MOID target
 
             skipped = 0;
 
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
             // Draw debug graphics, if applicable
             if (m_pDebugLayer)
                 m_pDebugLayer->SetPixel(intPos[X], intPos[Y], 120);
-#endif //_DEBUG
+#endif
         }
     }
 
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
     if (m_pDebugLayer)
         m_pDebugLayer->UnlockBitmaps();
-#endif //_DEBUG
+#endif
 
     // Didn't hit the target
     return false;
@@ -2751,10 +2751,10 @@ bool SceneMan::CastFindMORay(const Vector &start, const Vector &ray, MOID target
 
 float SceneMan::CastObstacleRay(const Vector &start, const Vector &ray, Vector &obstaclePos, Vector &freePos, MOID ignoreMOID, int ignoreTeam, unsigned char ignoreMaterial, int skip)
 {
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
     if (m_pDebugLayer)
         m_pDebugLayer->LockBitmaps();
-#endif //_DEBUG
+#endif
 
     int hitCount = 0, error, dom, sub, domSteps, skipped = skip;
     int intPos[2], delta[2], delta2[2], increment[2];
@@ -2860,20 +2860,20 @@ float SceneMan::CastObstacleRay(const Vector &start, const Vector &ray, Vector &
 
             skipped = 0;
 
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
             // Draw debug graphics, if applicable
             if (m_pDebugLayer)
                 m_pDebugLayer->SetPixel(intPos[X], intPos[Y], 13);
-#endif //_DEBUG
+#endif
         }
         else
             freePos.SetXY(intPos[X], intPos[Y]);
     }
 
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
     if (m_pDebugLayer)
         m_pDebugLayer->UnlockBitmaps();
-#endif //_DEBUG
+#endif
 
     // Add the pixel fraction to the free position if there were any free pixels
     if (domSteps != 0)
@@ -3722,10 +3722,11 @@ void SceneMan::Update(int screen)
 
     m_pMOColorLayer->SetOffset(m_Offset[screen]);
     m_pMOIDLayer->SetOffset(m_Offset[screen]);
-#ifdef _DEBUG
-    // Debug
+
+#ifdef DEBUG_BUILD
     m_pDebugLayer->SetOffset(m_Offset[screen]);
-#endif // _DEBUG
+#endif
+
     pTerrain->SetOffset(m_Offset[screen]);
     pTerrain->Update();
 
@@ -3751,14 +3752,12 @@ void SceneMan::Update(int screen)
     // Reset the timer so we can know the real time diff next frame
     m_ScrollTimer[screen].Reset();
 
-//#ifndef _DEBUG
     // Clean the color layer of the Terrain
     if (m_CleanTimer.GetElapsedSimTimeMS() > CLEANAIRINTERVAL)
     {
         pTerrain->CleanAir();
         m_CleanTimer.Reset();
     }
-//#endif // _DEBUG
 }
 
 
@@ -3847,10 +3846,10 @@ void SceneMan::Draw(BITMAP *pTargetBitmap, BITMAP *pTargetGUIBitmap, const Vecto
 
 //            sprintf(str, "Normal Layer Draw Mode\nHit M to cycle modes");
 //            g_FrameMan.DrawText(pTargetBitmap, str, Vector(475, 4), false);
-#ifdef _DEBUG
-            // Debug
+
+#ifdef DEBUG_BUILD
             m_pDebugLayer->Draw(pTargetBitmap, Box());
-#endif // _DEBUG
+#endif
     }
 }
 
@@ -3864,9 +3863,9 @@ void SceneMan::ClearMOColorLayer()
 {
     clear_to_color(m_pMOColorLayer->GetBitmap(), g_KeyColor);
 
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
     clear_to_color(m_pDebugLayer->GetBitmap(), g_KeyColor);
-#endif // _DEBUG
+#endif
 }
 
 

--- a/Managers/SceneMan.h
+++ b/Managers/SceneMan.h
@@ -517,7 +517,7 @@ public:
 // Method:          GetDebugBitmap
 //////////////////////////////////////////////////////////////////////////////////////////
 // Description:     Gets the bitmap of the SceneLayer that debug graphics is drawn onto.
-//                  Will only return valid BITMAP if building with _DEBUG.
+//                  Will only return valid BITMAP if building with DEBUG_BUILD.
 // Arguments:       None.
 // Return value:    A BITMAP pointer to the debug bitmap. Ownership is NOT transferred!
 

--- a/Managers/TimerMan.cpp
+++ b/Managers/TimerMan.cpp
@@ -274,7 +274,7 @@ void TimerMan::Update()
         m_SimUpdatesSinceDrawn = -1;
     }
 /*
-#ifdef _DEBUG
+#ifdef DEBUG_BUILD
     // Override the accumulator and just put one delta time in there so sim updates only once per frame
     m_SimAccumulator = m_DeltaTime;
 #endif // _DEBUG

--- a/Menus/MainMenuGUI.cpp
+++ b/Menus/MainMenuGUI.cpp
@@ -1833,9 +1833,9 @@ void MainMenuGUI::Update()
                 else if (anEvent.GetControl() == m_pLegalAgreementLink)
                 {
                     // Open the license agreement page
-#ifndef _DEBUG
+#ifndef DEBUG_BUILD
                     OpenBrowserToURL("http://steamcommunity.com/sharedfiles/workshoplegalagreement");
-#endif // _DEBUG
+#endif
                     // Show the publish button now
                     m_pPublishNextButton->SetVisible(true);
                 }
@@ -2170,7 +2170,7 @@ void MainMenuGUI::Draw(BITMAP *drawBitmap) const
 		if (pIcon)
 			draw_sprite(drawBitmap, pIcon->GetBitmaps8()[0], mouseX + 16, mouseY - 4);
 
-/*#ifdef _DEBUG
+/*#ifdef DEBUG_BUILD
 		if (g_UInputMan.JoystickActive(0))
 		{
 			Vector aim = g_UInputMan.AnalogAimValues(0);

--- a/RTEA.sln
+++ b/RTEA.sln
@@ -10,12 +10,15 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug Open Source|Win32 = Debug Open Source|Win32
 		Final Open Source|Win32 = Final Open Source|Win32
+		Minimal Debug Open Source|Win32 = Minimal Debug Open Source|Win32
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{A58C9DD7-8BC7-48DA-9E04-04D04F582BE3}.Debug Open Source|Win32.ActiveCfg = Debug Open Source|Win32
 		{A58C9DD7-8BC7-48DA-9E04-04D04F582BE3}.Debug Open Source|Win32.Build.0 = Debug Open Source|Win32
 		{A58C9DD7-8BC7-48DA-9E04-04D04F582BE3}.Final Open Source|Win32.ActiveCfg = Final Open Source|Win32
 		{A58C9DD7-8BC7-48DA-9E04-04D04F582BE3}.Final Open Source|Win32.Build.0 = Final Open Source|Win32
+		{A58C9DD7-8BC7-48DA-9E04-04D04F582BE3}.Minimal Debug Open Source|Win32.ActiveCfg = Minimal Debug Open Source|Win32
+		{A58C9DD7-8BC7-48DA-9E04-04D04F582BE3}.Minimal Debug Open Source|Win32.Build.0 = Minimal Debug Open Source|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/RTEA.vcxproj
+++ b/RTEA.vcxproj
@@ -9,6 +9,10 @@
       <Configuration>Final Open Source</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Minimal Debug Open Source|Win32">
+      <Configuration>Minimal Debug Open Source</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{A58C9DD7-8BC7-48DA-9E04-04D04F582BE3}</ProjectGuid>
@@ -29,6 +33,11 @@
     <CharacterSet>MultiByte</CharacterSet>
     <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Minimal Debug Open Source|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
@@ -40,14 +49,23 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Minimal Debug Open Source|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+  </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.40219.1</_ProjectFileVersion>
     <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug Open Source|Win32'">..\Cortex-Command-Community-Project-Data\</OutDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Minimal Debug Open Source|Win32'">..\CCCP Data\</OutDir>
     <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug Open Source|Win32'">_Bin\$(Configuration)\</IntDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Minimal Debug Open Source|Win32'">_Bin\$(Configuration)\</IntDir>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug Open Source|Win32'">true</LinkIncremental>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Minimal Debug Open Source|Win32'">true</LinkIncremental>
     <GenerateManifest Condition="'$(Configuration)|$(Platform)'=='Debug Open Source|Win32'">true</GenerateManifest>
+    <GenerateManifest Condition="'$(Configuration)|$(Platform)'=='Minimal Debug Open Source|Win32'">true</GenerateManifest>
     <EmbedManifest Condition="'$(Configuration)|$(Platform)'=='Debug Open Source|Win32'">false</EmbedManifest>
+    <EmbedManifest Condition="'$(Configuration)|$(Platform)'=='Minimal Debug Open Source|Win32'">false</EmbedManifest>
     <OutDir Condition="'$(Configuration)|$(Platform)'=='Final Open Source|Win32'">..\Cortex-Command-Community-Project-Data\</OutDir>
     <IntDir Condition="'$(Configuration)|$(Platform)'=='Final Open Source|Win32'">_Bin\$(Configuration)\</IntDir>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Final Open Source|Win32'">false</LinkIncremental>
@@ -55,6 +73,7 @@
     <EmbedManifest Condition="'$(Configuration)|$(Platform)'=='Final Open Source|Win32'">false</EmbedManifest>
     <TargetName Condition="'$(Configuration)|$(Platform)'=='Final Open Source|Win32'">Cortex Command</TargetName>
     <TargetName Condition="'$(Configuration)|$(Platform)'=='Debug Open Source|Win32'">Cortex Command.debug</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Minimal Debug Open Source|Win32'">Cortex Command.debug.minimal</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug Open Source|Win32'">
     <ClCompile>
@@ -78,6 +97,39 @@
     <Link>
       <AdditionalDependencies>lua5.1.x86.debug.lib;luabind.x86.debug.lib;ws2_32.lib;libcurl.lib;zlibwapi.lib;alld_s_c.lib;kernel32.lib;user32.lib;gdi32.lib;comdlg32.lib;ole32.lib;dinput.lib;dinput8.lib;ddraw.lib;dxguid.lib;winmm.lib;dsound.lib;libboost_thread-vc141-mt-gd-x32-1_69.lib;libboost_date_time-vc141-mt-gd-x32-1_69.lib;libboost_system-vc141-mt-gd-x32-1_69.lib;libboost_chrono-vc141-mt-gd-x32-1_69.lib;gorillaD.lib;legacy_stdio_definitions.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)Cortex Command.debug.exe</OutputFile>
+      <AdditionalLibraryDirectories>external/lib/win;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ProgramDatabaseFile>_Bin\$(Configuration)\RTEA.pdb</ProgramDatabaseFile>
+      <SubSystem>Windows</SubSystem>
+      <LinkTimeCodeGeneration>
+      </LinkTimeCodeGeneration>
+      <TargetMachine>MachineX86</TargetMachine>
+      <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
+      <ShowProgress>LinkVerbose</ShowProgress>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Minimal Debug Open Source|Win32'">
+    <ClCompile>
+      <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)System;$(ProjectDir)Entities;$(ProjectDir)Managers;$(ProjectDir)Menus;$(ProjectDir)GUI;$(ProjectDir)external\include\steam;$(ProjectDir)external\include\fmod;$(ProjectDir)external\include\luabind\2017;$(ProjectDir)external\include;$(ProjectDir)external\include\boost-1_69_0;$(ProjectDir)external\include\SDL;$(ProjectDir)external\include\SDL_mixer;$(ProjectDir)external\sources\RakNet;$(ProjectDir)System\LZ4</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;MIN_DEBUG_BUILD;_WINDOWS;DEBUGMODE;_CRT_SECURE_NO_DEPRECATE;_HAS_ITERATOR_DEBUGGING=0;ALLEGRO_STATICLINK;ALLEGRO_NO_ASM;ZLIB_WINAPI;__USE_SOUND_SDLMIXER_OFF;__USE_SOUND_FMOD_OFF;__USE_SOUND_GORILLA;__OPEN_SOURCE_EDITION;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild>false</MinimalRebuild>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <BufferSecurityCheck>true</BufferSecurityCheck>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level1</WarningLevel>
+      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <DisableSpecificWarnings>4312;4311;4786;4503;4800;4244;4204;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <ForcedIncludeFiles>%(ForcedIncludeFiles)</ForcedIncludeFiles>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>lua5.1.x86.debug.lib;luabind.x86.debug.lib;ws2_32.lib;libcurl.lib;zlibwapi.lib;alld_s_c.lib;kernel32.lib;user32.lib;gdi32.lib;comdlg32.lib;ole32.lib;dinput.lib;dinput8.lib;ddraw.lib;dxguid.lib;winmm.lib;dsound.lib;libboost_thread-vc141-mt-gd-x32-1_69.lib;libboost_date_time-vc141-mt-gd-x32-1_69.lib;libboost_system-vc141-mt-gd-x32-1_69.lib;libboost_chrono-vc141-mt-gd-x32-1_69.lib;gorillaD.lib;legacy_stdio_definitions.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)Cortex Command.debug.minimal.exe</OutputFile>
       <AdditionalLibraryDirectories>external/lib/win;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>_Bin\$(Configuration)\RTEA.pdb</ProgramDatabaseFile>

--- a/RTEA.vcxproj
+++ b/RTEA.vcxproj
@@ -80,7 +80,7 @@
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)System;$(ProjectDir)Entities;$(ProjectDir)Managers;$(ProjectDir)Menus;$(ProjectDir)GUI;$(ProjectDir)external\include\steam;$(ProjectDir)external\include\fmod;$(ProjectDir)external\include\luabind\2017;$(ProjectDir)external\include;$(ProjectDir)external\include\boost-1_69_0;$(ProjectDir)external\include\SDL;$(ProjectDir)external\include\SDL_mixer;$(ProjectDir)external\sources\RakNet;$(ProjectDir)System\LZ4</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;DEBUGMODE;_CRT_SECURE_NO_DEPRECATE;_HAS_ITERATOR_DEBUGGING=0;ALLEGRO_STATICLINK;ALLEGRO_NO_ASM;ZLIB_WINAPI;__USE_SOUND_SDLMIXER_OFF;__USE_SOUND_FMOD_OFF;__USE_SOUND_GORILLA;__OPEN_SOURCE_EDITION;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;DEBUG_BUILD;_WINDOWS;DEBUGMODE;_CRT_SECURE_NO_DEPRECATE;_HAS_ITERATOR_DEBUGGING=0;ALLEGRO_STATICLINK;ALLEGRO_NO_ASM;ZLIB_WINAPI;__USE_SOUND_SDLMIXER_OFF;__USE_SOUND_FMOD_OFF;__USE_SOUND_GORILLA;__OPEN_SOURCE_EDITION;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>

--- a/RTEA.vcxproj
+++ b/RTEA.vcxproj
@@ -57,7 +57,7 @@
   <PropertyGroup>
     <_ProjectFileVersion>10.0.40219.1</_ProjectFileVersion>
     <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug Open Source|Win32'">..\Cortex-Command-Community-Project-Data\</OutDir>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Minimal Debug Open Source|Win32'">..\CCCP Data\</OutDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Minimal Debug Open Source|Win32'">..\Cortex-Command-Community-Project-Data\</OutDir>
     <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug Open Source|Win32'">_Bin\$(Configuration)\</IntDir>
     <IntDir Condition="'$(Configuration)|$(Platform)'=='Minimal Debug Open Source|Win32'">_Bin\$(Configuration)\</IntDir>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug Open Source|Win32'">true</LinkIncremental>

--- a/RTEA.vcxproj.user
+++ b/RTEA.vcxproj.user
@@ -7,6 +7,10 @@
     <LocalDebuggerWorkingDirectory>$(OutDir)</LocalDebuggerWorkingDirectory>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Minimal Debug Open Source|Win32'">
+    <LocalDebuggerWorkingDirectory>$(OutDir)</LocalDebuggerWorkingDirectory>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Final Open Source|Win32'">
     <LocalDebuggerWorkingDirectory>$(OutDir)</LocalDebuggerWorkingDirectory>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>

--- a/System/DDTError.h
+++ b/System/DDTError.h
@@ -118,7 +118,7 @@ extern bool DDTAssert(bool expression,
 #endif // WIN32
 
 // Debug-only version of Assert
-#ifdef _DEBUG
+#if defined DEBUG_BUILD || defined MIN_DEBUG_BUILD
 
     #ifdef WIN32
 

--- a/System/Serializable.h
+++ b/System/Serializable.h
@@ -137,9 +137,7 @@ public:
     virtual int ReadProperty(std::string propName, Reader &reader)
     {
         reader.ReadPropValue();
-//#ifdef _DEBUG
         reader.ReportError("Could not match property");
-//#endif //_DEBUG
         return -1;
     }
 


### PR DESCRIPTION
Added a new build configuration for minimal debugging.

In this configuration all the visual debug features are disabled for a (lower than expected) ingame performance gain while keeping debugger functionality enabled.
Loading times and activity start times were unfortunately not improved but ingame there is a 10ish to 15 fps increase.

Debugger functionality appears to be intact at first glance but needs extensive fiddling by someone debugger-savvy (*cough* @garethyr ) to see if nothing got broken in the preprocessor definition rename.

Preprocessor definition was renamed because while using `_DEBUG` the configuration definition check was ignored and minimal debug was building with all the visual debugging enabled.
Not really sure why this was happening but renaming it seemed like the only way to get around this.

Further performance increase is possible by enabling code optimization but debugging optimized code seems to be not very fun or mental health safe so it should probably stay disabled for the debug configurations.