### PR TITLE
Gi71 explosive timers resetting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+
+### Changed
+
+### Removed
+
+### Fixed
+
+- Explosives (and other thrown devices) will no longer reset their explosion triggering timer when they're picked up ([Issue #71](https://github.com/cortex-command-community/Cortex-Command-Community-Project-Source/issues/71))
 
 ## [0.0.1.0] - 2020-01-27
 

--- a/Entities/ThrownDevice.cpp
+++ b/Entities/ThrownDevice.cpp
@@ -104,6 +104,19 @@ namespace RTE {
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+	void ThrownDevice::ResetAllTimers() {
+		double elapsedTime;
+		if (m_Activated) {
+			elapsedTime = m_ActivationTmr.GetElapsedSimTimeMS();
+		}
+		HeldDevice::ResetAllTimers();
+		if (m_Activated) {
+			m_ActivationTmr.SetElapsedSimTimeMS(elapsedTime);
+		}
+	}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 	void ThrownDevice::Activate() {
 		if (!m_Activated) {
 			m_ActivationTmr.Reset();

--- a/Entities/ThrownDevice.cpp
+++ b/Entities/ThrownDevice.cpp
@@ -6,7 +6,6 @@ namespace RTE {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 	void ThrownDevice::Clear() {
-		m_ThrownTmr.Reset();
 		m_ActivationSound.Reset();
 		m_StartThrowOffset.Reset();
 		m_EndThrowOffset.Reset();
@@ -34,8 +33,6 @@ namespace RTE {
 		HeldDevice::Create(reference);
 
 		m_MOType = MovableObject::TypeThrownDevice;
-
-		m_ThrownTmr = reference.m_ThrownTmr;
 
 		m_ActivationSound = reference.m_ActivationSound;
 

--- a/Entities/ThrownDevice.h
+++ b/Entities/ThrownDevice.h
@@ -76,7 +76,7 @@ namespace RTE {
 		/// <summary>
 		/// Resets all the timers used by this (e.g. emitters, etc). This is to prevent backed up emissions from coming out all at once while this has been held dormant in an inventory.
 		/// </summary>
-		virtual void ResetAllTimers() { HeldDevice::ResetAllTimers(); m_ThrownTmr.Reset(); }
+		virtual void ResetAllTimers();
 
 		/// <summary>
 		/// Activates this Device as long as it's not set to activate when released or it has no parent.

--- a/Entities/ThrownDevice.h
+++ b/Entities/ThrownDevice.h
@@ -144,8 +144,6 @@ namespace RTE {
 	protected:
 		static Entity::ClassInfo m_sClass; //! ClassInfo for this class
 
-		Timer m_ThrownTmr; //! Timer for timing how long ago this ThrownDevice was thrown
-
 		Sound m_ActivationSound; //! Activation sound
 
 		Vector m_StartThrowOffset; //! The position offset at which a throw of this Device begins


### PR DESCRIPTION
Closes #71 
Cleaned up an unused timer
Fixed attaching resetting activation timer by un-resetting it if the TD was activated. Might be worth doing all this more elegantly in future, but this is an okay solution.