### PR TITLE
Add rest detection to actors in MovableMan

### DIFF
--- a/Managers/MovableMan.cpp
+++ b/Managers/MovableMan.cpp
@@ -1768,6 +1768,7 @@ void MovableMan::Update()
                 (*aIt)->UpdateScript();
 				//g_FrameMan.StopPerformanceMeasurement(FrameMan::PERF_ACTORS_AI);
                 (*aIt)->ApplyImpulses();
+                (*aIt)->RestDetection();
             }
         }
 		g_FrameMan.StopPerformanceMeasurement(FrameMan::PERF_ACTORS_PASS2);


### PR DESCRIPTION
Adds RestDetection function call in MovableMan:Update for Actors where there previously was not.

Seems to have resolved #75 