### PR TITLE
time scale can no longer be reduced to 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Control schemes will no longer get deleted when being configured.
 Resetting the control scheme will load a preset instead of leaving it blank. (Issue #121)
 
+- Time scale can no longer be lowered to 0 through the performance stats interface.
+
 ### Removed
 
 ***

--- a/Managers/UInputMan.cpp
+++ b/Managers/UInputMan.cpp
@@ -2750,7 +2750,7 @@ int UInputMan::Update()
         // Manipulate timescaling
         if (KeyHeld(KEY_2))
             g_TimerMan.SetTimeScale(g_TimerMan.GetTimeScale() + 0.01);
-        if (KeyHeld(KEY_1) && g_TimerMan.GetTimeScale() > 0.01)
+        if (KeyHeld(KEY_1) && g_TimerMan.GetTimeScale() - 0.01 > 0.001)
             g_TimerMan.SetTimeScale(g_TimerMan.GetTimeScale() - 0.01);
 
         // Increase real to sim cap


### PR DESCRIPTION
time scale can no longer be reduced to 0. it was possible through float inaccuracy.