### PR TITLE
Gui combobox improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Game will now Abort with error message when trying to load a copy of a non-existent Presetname that is an AtomGroup, Attachable or AEmitter.
 
+- Comboboxes (dropdown lists) can now also be closed by clicking on their top part.
+
 ### Fixed
 
 - Fix crash when returning to `MetaGame` scenario screen after activity end.
@@ -130,6 +132,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Time scale can no longer be lowered to 0 through the performance stats interface.
 
 - Actors now support their held devices identically while facing to either side. ([Issue #31](https://github.com/cortex-command-community/Cortex-Command-Community-Project-Source/issues/31))
+
+- Fixed issue where clicking a combobox's scrollbar would release the mouse, thus causing unexpected behavior like not being able to close the list by clicking outside of it.
+
+- Fixed issue where comboboxes did not save the current selection, thus if the combobox was deselected without making a selection then the selection would revert to the default value instead of the last selected value.
+
+- Fixed issue with double clicks and missing clicks in menus (anything that uses AllegroInput).
 
 ### Removed
 

--- a/GUI/AllegroInput.cpp
+++ b/GUI/AllegroInput.cpp
@@ -236,16 +236,43 @@ void AllegroInput::Update(void)
 		m_PrevNetworkMouseButtonsStates[player][0] = m_NetworkMouseButtonsEvents[player][0];
 		m_PrevNetworkMouseButtonsStates[player][1] = m_NetworkMouseButtonsEvents[player][1];
 		m_PrevNetworkMouseButtonsStates[player][2] = m_NetworkMouseButtonsEvents[player][2];
-	}
-	else 
-	{
-		m_MouseButtonsEvents[0] = mouse_b & AMBLEFT ? (m_MouseButtonsStates[0] == Up ? Pushed : Repeat) : (m_MouseButtonsStates[0] == Down ? Released : None);
-		m_MouseButtonsEvents[1] = mouse_b & AMBMIDDLE ? (m_MouseButtonsStates[1] == Up ? Pushed : Repeat) : (m_MouseButtonsStates[1] == Down ? Released : None);
-		m_MouseButtonsEvents[2] = mouse_b & AMBRIGHT ? (m_MouseButtonsStates[2] == Up ? Pushed : Repeat) : (m_MouseButtonsStates[2] == Down ? Released : None);
+	} else {
+		if (!m_KeyJoyMouseCursor) {
+			if (mouse_b & AMBLEFT) {
+				m_MouseButtonsEvents[0] = (m_MouseButtonsStates[0] == Up) ? Pushed : Repeat;
+				m_MouseButtonsStates[0] = Down;
+			} else {
+				m_MouseButtonsEvents[0] = (m_MouseButtonsStates[0] == Down) ? Released : None;
+				m_MouseButtonsStates[0] = Up;
+			}
+		}
 
-		m_MouseButtonsStates[0] = mouse_b & AMBLEFT ? Down : Up;
-		m_MouseButtonsStates[1] = mouse_b & AMBMIDDLE ? Down : Up;
-		m_MouseButtonsStates[2] = mouse_b & AMBRIGHT ? Down : Up;
+		if (mouse_b & AMBMIDDLE) {
+			m_MouseButtonsEvents[1] = (m_MouseButtonsStates[1] == Up) ? Pushed : Repeat;
+			m_MouseButtonsStates[1] = Down;
+		} else {
+			m_MouseButtonsEvents[1] = (m_MouseButtonsStates[1] == Down) ? Released : None;
+			m_MouseButtonsStates[1] = Up;
+		}
+
+		if (mouse_b & AMBRIGHT) {
+			m_MouseButtonsEvents[2] = (m_MouseButtonsStates[2] == Up) ? Pushed : Repeat;
+			m_MouseButtonsStates[2] = Down;
+		} else {
+			m_MouseButtonsEvents[2] = (m_MouseButtonsStates[2] == Down) ? Released : None;
+			m_MouseButtonsStates[2] = Up;
+		}
+
+		if (m_Player < 0 || m_Player >= 4) {
+			for (int i = 0; i < 4; i++) {
+				m_MouseWheelChange = g_UInputMan.MouseWheelMovedByPlayer(i);
+				if (m_MouseWheelChange) {
+					break;
+				}
+			}
+		} else {
+			m_MouseWheelChange = g_UInputMan.MouseWheelMovedByPlayer(m_Player);
+		}
 	}
 
 	/*if (m_Player >= 0 && m_Player < 4)
@@ -307,29 +334,22 @@ void AllegroInput::Update(void)
         mouse_x = MIN((g_FrameMan.GetResX() * mouseDenominator) - 3, mouse_x);
         mouse_y = MIN((g_FrameMan.GetResY() * mouseDenominator) - 3, mouse_y);
 
-        // Button states/presses, Primary - ACTUALLY make either button work, we don't have use for secondary in menus
-        if (g_UInputMan.MenuButtonHeld(UInputMan::MENU_EITHER))
-        {
-            m_MouseButtonsStates[0] = Down;
-            m_MouseButtonsEvents[0] = Repeat;
-        }
-        if (g_UInputMan.MenuButtonPressed(UInputMan::MENU_EITHER))
-            m_MouseButtonsEvents[0] = Pushed;
-        else if (g_UInputMan.MenuButtonReleased(UInputMan::MENU_EITHER))
-            m_MouseButtonsEvents[0] = Released;
-/* Just do both
-        // Secondary
-        if (g_UInputMan.MenuButtonHeld(UInputMan::MENU_SECONDARY))
-        {
-            m_MouseButtonsStates[2] = Down;
-            m_MouseButtonsEvents[2] = Repeat;
-        }            
-        if (g_UInputMan.MenuButtonPressed(UInputMan::MENU_SECONDARY))
-            m_MouseButtonsEvents[2] = Pushed;
-        else if (g_UInputMan.MenuButtonReleased(UInputMan::MENU_SECONDARY))
-            m_MouseButtonsEvents[2] = Released;
-*/
-    }
+		// Button states/presses, Primary - ACTUALLY make either button work, we don't have use for secondary in menus
+		if (g_UInputMan.MenuButtonHeld(UInputMan::MENU_EITHER)) {
+			m_MouseButtonsStates[0] = Down;
+			m_MouseButtonsEvents[0] = Repeat;
+		}
+		if (g_UInputMan.MenuButtonPressed(UInputMan::MENU_EITHER)) {
+			m_MouseButtonsStates[0] = Down;
+			m_MouseButtonsEvents[0] = Pushed;
+		} else if (g_UInputMan.MenuButtonReleased(UInputMan::MENU_EITHER)) {
+			m_MouseButtonsStates[0] = Up;
+			m_MouseButtonsEvents[0] = Released;
+		} else if (m_MouseButtonsEvents[0] == Released) {
+			m_MouseButtonsStates[0] = Up;
+			m_MouseButtonsEvents[0] = None;
+		}
+	}
 
     // Update the mouse position of this GUIInput, based on the allegro mouse vars (which may have been altered by joystick or keyboard input)
 //    m_MouseX = mouse_x;
@@ -349,7 +369,7 @@ void AllegroInput::Update(void)
 // Method:          ConvertKeyEvent
 //////////////////////////////////////////////////////////////////////////////////////////
 // Description:     Converts from allegro's key push to that used by this GUI lib, with
-//                  timings for repats taken into consideration.
+//                  timings for repeats taken into consideration.
 
 void AllegroInput::ConvertKeyEvent(int allegroKey, int guilibKey, float elapsedS)
 {

--- a/GUI/AllegroInput.h
+++ b/GUI/AllegroInput.h
@@ -14,9 +14,9 @@
 
 
 enum aMButtons {
-    AMBLEFT = 1,
-    AMBRIGHT = 2,
-    AMBMIDDLE = 4
+    AMBLEFT = 1, // 0b1
+    AMBRIGHT = 2, // 0b10
+    AMBMIDDLE = 4 // 0b100
 };
 
 namespace RTE

--- a/GUI/GUIComboBox.cpp
+++ b/GUI/GUIComboBox.cpp
@@ -131,6 +131,7 @@ void GUIComboBox::Create(GUIProperties *Props)
     m_ListPanel->SetMultiSelect(false);
     m_ListPanel->SetHotTracking(true);
     m_ListPanel->EnableScrollbars(false, true);
+	m_ListPanel->SetMouseScrolling(true);
         
 
     // Create the button
@@ -273,121 +274,122 @@ GUIPanel *GUIComboBox::GetPanel(void)
 //////////////////////////////////////////////////////////////////////////////////////////
 // Description:     Called when receiving a signal.
 
-void GUIComboBox::ReceiveSignal(GUIPanel *Source, int Code, int Data)
+void GUIComboBox::ReceiveSignal(GUIPanel* Source, int Code, int Data)
 {
-    assert(Source);
+	assert(Source);
 
-    // ComboBoxButton
-    if (Source->GetPanelID() == m_Button->GetPanelID())
-    {
-        // Clicked
-        if (Code == GUIComboBoxButton::Clicked && !m_ListPanel->_GetVisible()) {
-            m_ListPanel->_SetVisible(true);
-            m_ListPanel->SetFocus();
-            m_ListPanel->CaptureMouse();
+	int sourcePanelID = Source->GetPanelID();
 
-            // Force a redraw
-            m_ListPanel->EndUpdate();
+	// ComboBoxButton
+	if (sourcePanelID == m_Button->GetPanelID())
+	{
+		// Clicked and list panel is not visible. open the list panel.
+		if (Code == GUIComboBoxButton::Clicked && !m_ListPanel->_GetVisible()) {
+			m_ListPanel->_SetVisible(true);
+			m_ListPanel->SetFocus();
+			m_ListPanel->CaptureMouse();
 
-            // Make this panel go above the rest
-            m_ListPanel->ChangeZPosition(TopMost);
+			// Force a redraw
+			m_ListPanel->EndUpdate();
 
-            // Save the current selection
-            if (m_ListPanel->GetSelectedIndex() >= 0 && m_ListPanel->GetSelectedIndex() < m_ListPanel->GetSelectionList()->size())
-                m_OldSelection = m_ListPanel->GetSelectedIndex();
-
-            AddEvent(GUIEvent::Notification, Dropped, 0);
-        }
-    }
-
-    // Textbox
-    if (Source->GetPanelID() == m_TextPanel->GetPanelID()) {
-        
-        // MouseDown
-        if (Code == GUITextPanel::MouseDown && m_DropDownStyle == DropDownList && Data & MOUSE_LEFT) {
-            // Drop
-            m_ListPanel->_SetVisible(true);
-            m_ListPanel->SetFocus();
-            m_ListPanel->CaptureMouse();
-
-            // Force a redraw
-            m_ListPanel->EndUpdate();
-
-            // Make this panel go above the rest
-            m_ListPanel->ChangeZPosition(TopMost);
+			// Make this panel go above the rest
+			m_ListPanel->ChangeZPosition(TopMost);
 
             // Save the current selection
-            if (m_ListPanel->GetSelectedIndex() >= 0 && m_ListPanel->GetSelectedIndex() < m_ListPanel->GetSelectionList()->size())
+            if (m_ListPanel->GetSelectedIndex() >= 0 && m_ListPanel->GetSelectedIndex() < m_ListPanel->GetItemList()->size())
                 m_OldSelection = m_ListPanel->GetSelectedIndex();
 
-            AddEvent(GUIEvent::Notification, Dropped, 0);
-        }
+			AddEvent(GUIEvent::Notification, Dropped, 0);
+		}
+	}
 
-    }
+	// Textbox
+	else if (sourcePanelID == m_TextPanel->GetPanelID()) {
 
-    // ListPanel
-    if (Source->GetPanelID() == m_ListPanel->GetPanelID()) {
+		// MouseDown
+		if (Code == GUITextPanel::MouseDown && m_DropDownStyle == DropDownList && Data & MOUSE_LEFT) {
+			// Drop
+			m_ListPanel->_SetVisible(true);
+			m_ListPanel->SetFocus();
+			m_ListPanel->CaptureMouse();
 
-        // MouseMove
-        if (Code == GUIListPanel::MouseMove)// || Code == GUIListPanel::MouseUp)
-        {
-            m_Button->SetPushed(false);
-            return;
-        }
-    
-        // Click
-        int mouseX = 0;
-        int mouseY = 0;
-        m_Manager->GetInputController()->GetMousePosition(&mouseX, &mouseY);
-        // Unless we check for the mouse not being over the otehr components, this causes irritating accidental closing of the list when clicking on the textbox and button
-        if (Code == GUIListPanel::Click && !m_TextPanel->PointInside(mouseX, mouseY) && !m_Button->PointInside(mouseX, mouseY))
-        {
-            // Hide the list panel
-            m_ListPanel->_SetVisible(false);
-            m_ListPanel->ReleaseMouse();
-            m_Manager->SetFocus(0);
-            m_Button->SetPushed(false);
+			// Force a redraw
+			m_ListPanel->EndUpdate();
 
-            // Restore the old selection
-            m_ListPanel->SetSelectedIndex(m_OldSelection);
+			// Make this panel go above the rest
+			m_ListPanel->ChangeZPosition(TopMost);
 
-            AddEvent(GUIEvent::Notification, Closed, 0);
-        }
+            // Save the current selection
+            if (m_ListPanel->GetSelectedIndex() >= 0 && m_ListPanel->GetSelectedIndex() < m_ListPanel->GetItemList()->size())
+                m_OldSelection = m_ListPanel->GetSelectedIndex();
 
-        // Select on mouseup instead of down so we don't accidentally click stuff behind the disappearing listbox immediately after
-        // Also only work if inside the acutal list, and not its scrollbars
-        if (Code == GUIListPanel::MouseUp && m_ListPanel->PointInsideList(mouseX, mouseY)) {
-            // Hide the list panel
-            m_ListPanel->_SetVisible(false);
-            m_ListPanel->ReleaseMouse();
-            m_Manager->SetFocus(0);
-            m_Button->SetPushed(false);
+			AddEvent(GUIEvent::Notification, Dropped, 0);
+		}
 
-            AddEvent(GUIEvent::Notification, Closed, 0);
+	}
 
-            // Set the text to the item in the list panel
-            GUIListPanel::Item *Item = m_ListPanel->GetSelected();
-            if (Item)
-            {
-                m_TextPanel->SetText(Item->m_Name);
-                // Save the current selection - NO, don't, we want to keep this so we can still roll back to previous selection later
+	// ListPanel
+	else if (sourcePanelID == m_ListPanel->GetPanelID()) {
+
+		// MouseMove
+		if (Code == GUIListPanel::MouseMove)// || Code == GUIListPanel::MouseUp)
+		{
+			m_Button->SetPushed(false);
+			return;
+		}
+
+		int mouseX = 0;
+		int mouseY = 0;
+		m_Manager->GetInputController()->GetMousePosition(&mouseX, &mouseY);
+		// Mouse down anywhere outside the list panel.
+		if (Code == GUIListPanel::Click)
+		{
+			// Hide the list panel
+			m_ListPanel->_SetVisible(false);
+			m_ListPanel->ReleaseMouse();
+			m_Manager->SetFocus(0);
+			m_Button->SetPushed(false);
+
+			// Restore the old selection
+			m_ListPanel->SetSelectedIndex(m_OldSelection);
+
+			AddEvent(GUIEvent::Notification, Closed, 0);
+		}
+
+		// Select on mouseup instead of down so we don't accidentally click stuff behind the disappearing listbox immediately after
+		// Also only work if inside the actual list, and not its scrollbars
+		else if (Code == GUIListPanel::MouseUp && m_ListPanel->PointInsideList(mouseX, mouseY)) {
+			// Hide the list panel
+			m_ListPanel->_SetVisible(false);
+			m_ListPanel->ReleaseMouse();
+			m_Manager->SetFocus(0);
+			m_Button->SetPushed(false);
+
+			AddEvent(GUIEvent::Notification, Closed, 0);
+
+			// Set the text to the item in the list panel
+			GUIListPanel::Item* Item = m_ListPanel->GetSelected();
+			if (Item)
+			{
+				m_TextPanel->SetText(Item->m_Name);
+				// Save the current selection - NO, don't, we want to keep this so we can still roll back to previous selection later
 //                m_OldSelection = m_ListPanel->GetSelectedIndex();
-            }
-            else
-            {
-                // Restore the old selection
-                m_ListPanel->SetSelectedIndex(m_OldSelection);
-            }
-        }
+			}
+			else
+			{
+				// Restore the old selection
+				m_ListPanel->SetSelectedIndex(m_OldSelection);
+			}
+		}
 
-        if (m_DropDownStyle == DropDownList) {
-            // Set the text to the item in the list panel
-            GUIListPanel::Item *Item = m_ListPanel->GetSelected();
-            if (Item)
-                m_TextPanel->SetText(Item->m_Name);
-        }
+		if (m_DropDownStyle == DropDownList) {
+			// Set the text to the item in the list panel
+			GUIListPanel::Item* Item = m_ListPanel->GetSelected();
+			if (Item)
+				m_TextPanel->SetText(Item->m_Name);
+		}
 
-    }
+	}
 }
 
 

--- a/GUI/GUIInput.cpp
+++ b/GUI/GUIInput.cpp
@@ -55,6 +55,8 @@ GUIInput::GUIInput(int whichPlayer, bool keyJoyMouseCursor)
     m_KeyJoyMouseCursor = keyJoyMouseCursor;
 
 	m_Player = whichPlayer;
+
+	m_MouseWheelChange = 0;
 }
 
 

--- a/GUI/GUIInput.h
+++ b/GUI/GUIInput.h
@@ -174,6 +174,15 @@ public:
     int GetModifier(void);
 
 
+	/// <summary>
+	/// This function returns how much the mouse scroll wheel has moved. Positive integer is scroll up, negative is scroll down.
+	/// </summary>
+	/// <returns>Mouse scroll wheel movement in integer value.</returns>
+	int GetMouseWheelChange() {
+		return m_MouseWheelChange;
+	}
+
+
 //////////////////////////////////////////////////////////////////////////////////////////
 // Private member variable and method declarations
 
@@ -191,8 +200,8 @@ protected:
 
     // Mouse button states
     // Order:    Left, Middle, Right
-    int            m_MouseButtonsEvents[3];
-    int            m_MouseButtonsStates[3];
+	int            m_MouseButtonsEvents[3];
+	int            m_MouseButtonsStates[3];
 
 	static int            m_NetworkMouseButtonsEvents[4][3];
 	static int            m_NetworkMouseButtonsStates[4][3];
@@ -207,12 +216,14 @@ protected:
 
 	int				m_Player;
 
+	int				m_MouseWheelChange; //!< the amount and direction that the mouse wheel has moved.
+
     // These offset the mouse positions so that the cursor is shifted for all events
     int            m_MouseOffsetX, m_MouseOffsetY;
 
     int            m_Modifier;
 
-    // Whether the keyboard and joysticks also control the mouise
+    // Whether the keyboard and joysticks also control the mouse
     bool           m_KeyJoyMouseCursor;
 };
 

--- a/GUI/GUIListBox.cpp
+++ b/GUI/GUIListBox.cpp
@@ -188,33 +188,23 @@ void GUIListBox::ReceiveSignal(GUIPanel *Source, int Code, int Data)
 {
     if (Source->GetPanelID() == GetPanelID())
     {
-        // MouseMove
-        if (Code == GUIListPanel::MouseMove)
-            AddEvent(GUIEvent::Notification, MouseMove, Data);
-
-        // MouseEnter
-        if (Code == GUIListPanel::MouseEnter)
-            AddEvent(GUIEvent::Notification, MouseEnter, Data);
-
-        // MouseLeave
-        if (Code == GUIListPanel::MouseLeave)
-            AddEvent(GUIEvent::Notification, MouseLeave, Data);
-
-        // Select
-        if (Code == GUIListPanel::Select)
-            AddEvent(GUIEvent::Notification, Select, 0);
-
-        // MouseDown
-        if (Code == GUIListPanel::MouseDown)
-            AddEvent(GUIEvent::Notification, MouseDown, 0);
-
-        // Double click
-        if (Code == GUIListPanel::DoubleClick)
-            AddEvent(GUIEvent::Notification, DoubleClick, 0);
-
-        // KeyDown
-        if (Code == GUIListPanel::KeyDown)
-            AddEvent(GUIEvent::Notification, KeyDown, Data);
+		if (Code == GUIListPanel::MouseMove) {
+			AddEvent(GUIEvent::Notification, MouseMove, Data);
+		} else if (Code == GUIListPanel::MouseEnter) {
+			AddEvent(GUIEvent::Notification, MouseEnter, Data);
+		} else if (Code == GUIListPanel::MouseLeave) {
+			AddEvent(GUIEvent::Notification, MouseLeave, Data);
+		} else if (Code == GUIListPanel::Select) {
+			AddEvent(GUIEvent::Notification, Select, 0);
+		} else if (Code == GUIListPanel::MouseDown) {
+			AddEvent(GUIEvent::Notification, MouseDown, 0);
+		} else if (Code == GUIListPanel::DoubleClick) {
+			AddEvent(GUIEvent::Notification, DoubleClick, 0);
+		} else if (Code == GUIListPanel::KeyDown) {
+			AddEvent(GUIEvent::Notification, KeyDown, Data);
+		} else if (Code == GUIListPanel::EdgeHit) {
+			AddEvent(GUIEvent::Notification, EdgeHit, Data);
+		}
     }
 
     GUIListPanel::ReceiveSignal(Source, Code, Data);

--- a/GUI/GUIListPanel.h
+++ b/GUI/GUIListPanel.h
@@ -50,7 +50,8 @@ public:
         MouseEnter, // Mouse left the panel
         MouseLeave, // Mouse left the panel
         DoubleClick,// Double click
-        KeyDown    // Key Down
+		KeyDown,    // Key Down
+		EdgeHit //!< Tried scrolling the selection past the first or last item. data = 0 for top edge, data = 1 for bottom edge.
     } Signal;
 
     // Item structure
@@ -207,6 +208,16 @@ public:
 // Arguments:       Mouse Position, Mouse Buttons, Modifier.
 
     virtual void OnDoubleClick(int X, int Y, int Buttons, int Modifier);
+
+
+	/// <summary>
+	/// Called when the mouse scroll wheel is moved.
+	/// </summary>
+	/// <param name="x">Mouse X position.</param>
+	/// <param name="y">Mouse Y position.</param>
+	/// <param name="modifier">Activated modifier buttons.</param>
+	/// <param name="mouseWheelChange">The amount of wheel movement. Positive is scroll up, negative is scroll down.</param>
+	void OnMouseWheelChange(int x, int y, int modifier, int mouseWheelChange) override;
 
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -500,6 +511,20 @@ public:
     void ScrollToBottom();
 
 
+	/// <summary>
+	/// Sets whether the scroll panel scrolls in a loop or not.
+	/// </summary>
+	/// <param name="scrollLoop">True to scroll in a loop, false to scroll with edge stopping.</param>
+	void SetSelectionScrollingLoop(bool scrollLoop);
+
+
+	/// <summary>
+	/// Sets whether the list panel can be scrolled with the mouse scroll wheel.
+	/// </summary>
+	/// <param name="mouseScroll">True to enable scrolling, false to disable.</param>
+	void SetMouseScrolling(bool mouseScroll);
+
+
 //////////////////////////////////////////////////////////////////////////////////////////
 // Protected member variable and method declarations
 
@@ -548,6 +573,20 @@ private:
     void SelectItem(int X, int Y, int Modifier);
 
 
+	/// <summary>
+	/// Perform list scrolling through the scrollbar.
+	/// </summary>
+	/// <param name="MouseWheelChange">Amount and direction of scrolling. Positive to scroll up, negative to scroll down.</param>
+	void ScrollBarScrolling(int mouseWheelChange);
+
+
+	/// <summary>
+	/// Perform list scrolling by changing the currently selected list item.
+	/// </summary>
+	/// <param name="MouseWheelChange">Amount and direction of scrolling. Positive to scroll up, negative to scroll down.</param>
+	void SelectionListScrolling(int mouseWheelChange);
+
+
 // Members    
 
     GUISkin                *m_Skin;
@@ -571,6 +610,8 @@ private:
     bool                m_MultiSelect;
     bool                m_HotTracking;
     int                    m_LastSelected;
+	bool				m_LoopSelectionScroll; //!< Whether the list panel scrolls in a loop or not, while scrolling the selection list (as opposed to the scrollbar).
+	bool				m_MouseScroll; //!< Whether the list panel enables scrolling with the mouse scroll wheel.
     
     // This draws items differently, not with boxes etc.
     bool                m_AlternateDrawMode;

--- a/GUI/GUIManager.cpp
+++ b/GUI/GUIManager.cpp
@@ -123,6 +123,7 @@ void GUIManager::Update(void)
     int MouseX = 0, MouseY = 0;
     int DeltaX, DeltaY;    
     int MouseButtons[3], MouseStates[3];
+	int MouseWheelChange = 0;
     int Released = GUIPanel::MOUSE_NONE;
     int Pushed = GUIPanel::MOUSE_NONE;
     int Buttons = GUIPanel::MOUSE_NONE;
@@ -148,7 +149,7 @@ void GUIManager::Update(void)
     {
         m_Input->GetMousePosition(&MouseX, &MouseY);
         m_Input->GetMouseButtons(MouseButtons, MouseStates);
-        Modifier = m_Input->GetModifier();
+		MouseWheelChange = m_Input->GetMouseWheelChange();
 
         // Calculate mouse movement
         DeltaX = MouseX - m_OldMouseX;
@@ -269,6 +270,12 @@ void GUIManager::Update(void)
             if (m_MouseOverPanel)
                 m_MouseOverPanel->OnMouseLeave(MouseX, MouseY, Buttons, Mod);
         }
+
+		if (MouseWheelChange) {
+			if (CurPanel) {
+				CurPanel->OnMouseWheelChange(MouseX, MouseY, Mod, MouseWheelChange);
+			}
+		}
 
         m_MouseOverPanel = CurPanel;
     }

--- a/GUI/GUIPanel.h
+++ b/GUI/GUIPanel.h
@@ -235,6 +235,16 @@ public:
     virtual void OnMouseHover(int X, int Y, int Buttons, int Modifier);
 
 
+	/// <summary>
+	/// Called when the mouse scroll wheel is moved.
+	/// </summary>
+	/// <param name="x">Mouse X position.</param>
+	/// <param name="y">Mouse Y position.</param>
+	/// <param name="modifier">Activated modifier buttons.</param>
+	/// <param name="mouseWheelChange">The amount of wheel movement. Positive is scroll up, negative is scroll down.</param>
+	virtual void OnMouseWheelChange(int x, int y, int modifier, int mouseWheelChange) {};
+
+
 //////////////////////////////////////////////////////////////////////////////////////////
 // Virtual Method:  OnKeyDown
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/Menus/BuyMenuGUI.cpp
+++ b/Menus/BuyMenuGUI.cpp
@@ -1080,7 +1080,7 @@ void BuyMenuGUI::Update()
         }
 
         // Switch back focus to the category list if the player presses up while on the save button
-        if (m_pController->IsState(PRESS_UP) || m_pController->IsState(SCROLL_UP))
+        if (pressUp)
         {
             if (m_pSaveButton->HasFocus())
             {
@@ -1093,7 +1093,7 @@ void BuyMenuGUI::Update()
                 g_GUISound.SelectionChangeSound()->Play(m_pController->GetPlayer());
             }
         }
-        else if (m_pController->IsState(PRESS_DOWN) || m_pController->IsState(SCROLL_DOWN))
+        else if (pressDown)
         {
             if (m_pSaveButton->HasFocus())
             {
@@ -1413,12 +1413,12 @@ void BuyMenuGUI::Update()
         }
 
         // Switch back focus to the order list if the player presses up
-        if (m_pController->IsState(PRESS_UP) || m_pController->IsState(SCROLL_UP))
+        if (pressUp)
         {
             m_MenuFocus = ORDER;
             m_FocusChange = -1;
         }
-        else if (m_pController->IsState(PRESS_DOWN) || m_pController->IsState(SCROLL_DOWN))
+        else if (pressDown)
             g_GUISound.UserErrorSound()->Play(m_pController->GetPlayer());
     }
 


### PR DESCRIPTION
resolves #135 

- Fixes in AllegroInput.cpp to prevent double clicks and missing clicks.
- Fixed typo in GUIComboBox which created unexpected behavior.
- Refined hot tracking in GUIListPanel so it doesn't send redundant "select" signals.
- Change in combobox now lets the user close the combobox by clicking the top part, possible due to the fixes in AllegroInput.cpp.
- Fix in GUIListPanel resolves issue where clicking the list panel's scrollbar releases the mouse and prevents closing the list panel.
- Added mouse wheel detection infrastructure to AllegroInput, GUIInput, GUIManager and GUIPanel.
- Added mouse wheel scrolling and looped scrolling capabilities to GUIListPanel, disabled by default to prevent conflict with menus like the buy menu. Can be enabled by default in the future together with changes to these menus to take advantage of this new capability.
- Set combobox default behavior to enable scrolling with mouse wheel.
- Added EdgeHit GUIEvent in GUIListBox, which is useful for things like the buy menu, where scrolling past the bottom of the cart list should change focus to the buy button.
- Added Edgehit signal to GUIListPanel.