### PR TITLE
Fix Lua PlaySound attenuation

### DIFF
--- a/Entities/SoundContainer.cpp
+++ b/Entities/SoundContainer.cpp
@@ -159,7 +159,6 @@ namespace RTE {
 			return;
 		}
 
-		attenuationStartDistance = (attenuationStartDistance < 0) ? c_DefaultAttenuationStartDistance : attenuationStartDistance;
 		soundSet.push_back({soundFile, soundObject, offset, minimumAudibleDistance, attenuationStartDistance});
 		if (soundSetIndex >= m_SoundSets.size()) { m_SoundSets.push_back(soundSet); }
 

--- a/Entities/SoundContainer.h
+++ b/Entities/SoundContainer.h
@@ -155,9 +155,9 @@ namespace RTE {
 		/// </summary>
 		/// <param name="soundFilePath">A path to the new sound to add. This will be handled through PresetMan.</param>
 		/// <param name="offset">The offset position to play this sound at, where (0, 0) is no offset.</param>
-		/// <param name="attenuationStartDistance">The attenuation start distance for this sound, -1 is default.</param>
+		/// <param name="attenuationStartDistance">The attenuation start distance for this sound, -1 means it uses the parent SoundContainer's attenuation start distance.</param>
 		/// <param name="abortGameForInvalidSound">Whether to abort the game if the sound couldn't be added, or just show a console error.</param>
-		void AddSound(const std::string &soundFilePath, const Vector &offset, float attenuationStartDistance, bool abortGameForInvalidSound) { return AddSound(soundFilePath, m_SoundSets.size() + 1, Vector(), 0, c_DefaultAttenuationStartDistance, abortGameForInvalidSound); }
+		void AddSound(const std::string &soundFilePath, const Vector &offset, float attenuationStartDistance, bool abortGameForInvalidSound) { return AddSound(soundFilePath, m_SoundSets.size(), Vector(), 0, attenuationStartDistance, abortGameForInvalidSound); }
 
 		/// <summary>
 		/// Adds a new sound to this SoundContainer, either spitting out a lua error or aborting if it fails.

--- a/Entities/SoundContainer.h
+++ b/Entities/SoundContainer.h
@@ -147,7 +147,7 @@ namespace RTE {
 		/// </summary>
 		/// <param name="soundFilePath">A path to the new sound to add. This will be handled through PresetMan.</param>
 		/// <param name="abortGameForInvalidSound">Whether to abort the game if the sound couldn't be added, or just show a console error.</param>
-		void AddSound(const std::string &soundFilePath, bool abortGameForInvalidSound) { return AddSound(soundFilePath, Vector(), c_DefaultAttenuationStartDistance, abortGameForInvalidSound); }
+		void AddSound(const std::string &soundFilePath, bool abortGameForInvalidSound) { return AddSound(soundFilePath, Vector(), -1, abortGameForInvalidSound); }
 
 		/// <summary>
 		/// Adds a new sound to this SoundContainer, either spitting out a lua error or aborting if it fails.


### PR DESCRIPTION
AddSound was the culprit as it was specifically setting a Sound's attenuationstartdist to 100, which overwrote the SoundContainer's. now it sets it to -1, which will make it follow the SoundContainer's properly.