### PR TITLE
Update Vector::SetMagnitude

### DIFF
--- a/System/Vector.cpp
+++ b/System/Vector.cpp
@@ -35,9 +35,11 @@ namespace RTE {
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 	Vector & Vector::SetMagnitude(float newMag) {
-		Vector temp(*this);
-		SetXY(newMag, 0);
-		AbsRotateTo(temp);
+		if (IsZero()) {
+			SetXY(newMag, 0.0F);
+		} else {
+			*this *= newMag / GetMagnitude();
+		}
 		return *this;
 	}
 
@@ -52,7 +54,7 @@ namespace RTE {
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 	float Vector::GetAbsRadAngle() const {
-		float radAngle = -std::atan2(m_Y, m_X);
+		const float radAngle = -std::atan2(m_Y, m_X);
 		return (radAngle < -c_HalfPI) ? (radAngle + c_TwoPI) : radAngle;
 	}
 
@@ -60,8 +62,8 @@ namespace RTE {
 
 	Vector & Vector::RadRotate(float angle) {
 		angle = -angle;
-		float tempX = m_X * std::cos(angle) - m_Y * std::sin(angle);
-		float tempY = m_X * std::sin(angle) + m_Y * std::cos(angle);
+		const float tempX = m_X * std::cos(angle) - m_Y * std::sin(angle);
+		const float tempY = m_X * std::sin(angle) + m_Y * std::cos(angle);
 		m_X = tempX;
 		m_Y = tempY;
 
@@ -86,7 +88,7 @@ namespace RTE {
 			for (const Vector &vector : rhs) {
 				*this += vector;
 			}
-			*this /= rhs.size();
+			*this /= static_cast<float>(rhs.size());
 		}
 		return *this;
 	}

--- a/System/Vector.cpp
+++ b/System/Vector.cpp
@@ -38,7 +38,7 @@ namespace RTE {
 		if (IsZero()) {
 			SetXY(newMag, 0.0F);
 		} else {
-			*this *= newMag / GetMagnitude();
+			*this *= (newMag / GetMagnitude());
 		}
 		return *this;
 	}

--- a/System/Vector.h
+++ b/System/Vector.h
@@ -190,7 +190,7 @@ namespace RTE {
 		float GetMagnitude() const { return std::sqrt(std::pow(m_X, 2.0F) + std::pow(m_Y, 2.0F)); }
 
 		/// <summary>
-		/// Sets the magnitude of this Vector and keeps its angle intact.
+		/// Sets the magnitude of this Vector. A negative magnitude will invert the Vector's direction.
 		/// </summary>
 		/// <param name="newMag">A float value that the magnitude will be set to.</param>
 		/// <returns>A reference to this after the change.</returns>
@@ -312,13 +312,13 @@ namespace RTE {
 		/// Returns the greatest integer that is not greater than the X value of this Vector.
 		/// </summary>
 		/// <returns>An int value that represents the X value of this Vector.</returns>
-		int GetFloorIntX() const { return static_cast<int>(std::floor(m_X)); }
+		int GetFloorIntX() const { return static_cast<int>(m_X); }
 
 		/// <summary>
 		/// Returns the greatest integer that is not greater than the Y value of this Vector.
 		/// </summary>
 		/// <returns>An int value that represents the Y value of this Vector.</returns>
-		int GetFloorIntY() const { return static_cast<int>(std::floor(m_Y)); }
+		int GetFloorIntY() const { return static_cast<int>(m_Y); }
 
 		/// <summary>
 		/// Returns a ceilinged copy of this Vector. Does not alter this Vector.


### PR DESCRIPTION
This should be more efficient, and it will also be slightly more precise.
In the previous version vectors like (0,2) would become (1.246387e-8, 3) when rescaled to 3.
In this version that won't happen.