### PR TITLE
Penetrating atoms actually do something

### DIFF
--- a/Entities/AtomGroup.cpp
+++ b/Entities/AtomGroup.cpp
@@ -1192,17 +1192,10 @@ float AtomGroup::Travel(Vector &position,
             // Special case of being at rest
             if (stepCount == 0 && stepsOnSeg == 1)
             {
-                segProgress = 0.0F;
                 halted = true;
 //                m_pOwnerMO->SetToSettle(true);
-            }
-            // Normal travel
-			else if (stepCount == 0) {
-				// Hit on first atom, but has farther to go
-				segProgress = 0.75F / static_cast<float>(stepsOnSeg);
-			} else {
-				segProgress = static_cast<float>(stepCount) / static_cast<float>(stepsOnSeg);
 			}
+			segProgress = static_cast<float>(stepCount) / static_cast<float>(stepsOnSeg);
 
             // Move position forward to the hit position.
             preHitPos = position;
@@ -1298,8 +1291,6 @@ float AtomGroup::Travel(Vector &position,
 				// Calc and store the collision response effects.
 				for (Atom *penetratingAtom : penetratingAtoms)
 				{
-
-
 					// This gets re-set later according to the ortho pixel edges hit.
 //                  hitData.BitmapNormal = -(hitData.HitVel[HITOR].GetNormalized());
 //                  hitData.SquaredMIHandle[HITOR] = hitData.HitRadius[HITOR].GetPerpendicular()/*.Dot(hitData.BitmapNormal)*/;


### PR DESCRIPTION
Previously:
Some atoms hit the terrain.
If all the atoms _can_ penetrate then they all penetrate.
If at least one atom can't penetrate then none of them penetrate.

Now:
Any atom that _can_ penetrate _will_ penetrate.

Also, removal of weird hardcoded three-quarter steps and removal of MO position change in the middle of the travel segment.

End result is that objects behave nicer when colliding and also there are less visual artifacts of objects intersecting with terrain that they have not penetrated.

Current development:
![allpen_dev_1](https://user-images.githubusercontent.com/16946404/93630050-ffaa3200-f9f1-11ea-82eb-a86cfb93eab0.gif)

After letting the penetrating atoms actually penetrate, and eliminating mid-segment position change:
![allpen_yes_1](https://user-images.githubusercontent.com/16946404/93630082-12246b80-f9f2-11ea-9597-e1a15ab52ef9.gif)

After removal of three-quarters step:
![allpen_noquarter_1](https://user-images.githubusercontent.com/16946404/93630180-384a0b80-f9f2-11ea-8b17-79c100d354db.gif)

Main change from first to second: The "Grass "block. Object cuts clean through the grass.
Main change from second to third: The "Tough" block. Object does not intersect and get stuck on the red block, which is impenetrable.

And this is Pre-2, for reference:
![cortex command 18_09_2020 21_17_33](https://user-images.githubusercontent.com/16946404/93631665-a394dd00-f9f4-11ea-97ea-894428459e11.png)
