### PR TITLE
Version number

### DIFF
--- a/GUI/GUILabel.h
+++ b/GUI/GUILabel.h
@@ -191,7 +191,7 @@ public:
 // Method:          SetHAlignment
 //////////////////////////////////////////////////////////////////////////////////////////
 // Description:     Sets the horizontal alignment of the text of this label.
-// Arguments:       Teh desired alignement.
+// Arguments:       The desired alignement.
 
     void SetHAlignment(int HAlignment = GUIFont::Left) { m_HAlignment = HAlignment; }
 
@@ -200,7 +200,7 @@ public:
 // Method:          SetVAlignment
 //////////////////////////////////////////////////////////////////////////////////////////
 // Description:     Sets the vertical alignment of the text of this label.
-// Arguments:       Teh desired alignement.
+// Arguments:       The desired alignement.
 
     void SetVAlignment(int VAlignment = GUIFont::Top) { m_VAlignment = VAlignment; }
 
@@ -218,7 +218,7 @@ public:
 // Method:          GetVAlignment
 //////////////////////////////////////////////////////////////////////////////////////////
 // Description:     Gets the vertical alignment of the text of this label.
-// Arguments:       Teh desired alignement.
+// Arguments:       The desired alignement.
 
     int GetVAlignment() { return m_VAlignment; }
 

--- a/GUI/GUIPanel.cpp
+++ b/GUI/GUIPanel.cpp
@@ -127,11 +127,10 @@ void GUIPanel::AddChild(GUIPanel *child, bool convertToAbsolutePos)
         child->m_Width = std::max(child->m_Width, 0);
         child->m_Height = std::max(child->m_Height, 0);
 
-        int Zpos = 0;
-        // Get the last child in the list
+        int zPos = 0;
         if (m_Children.size() > 0) {
 			GUIPanel *lastChild = m_Children.back();
-			Zpos = lastChild->GetZPos() + 1;
+			zPos = lastChild->GetZPos() + 1;
         }
 
         // Remove the child from any previous parent
@@ -141,7 +140,7 @@ void GUIPanel::AddChild(GUIPanel *child, bool convertToAbsolutePos)
 
         // Setup the inherited values
         child->m_Parent = this;
-        child->Setup(m_Manager, Zpos);
+        child->Setup(m_Manager, zPos);
 
         // Add the child to the list
         m_Children.push_back(child);

--- a/GUI/GUIPanel.cpp
+++ b/GUI/GUIPanel.cpp
@@ -124,23 +124,24 @@ void GUIPanel::AddChild(GUIPanel *child, bool convertToAbsolutePos)
             child->m_Height -= (child->m_Y + child->m_Height) - (m_Y + m_Height);
 */
         // Make sure the rectangle is valid
-        child->m_Width = MAX(child->m_Width, 0);
-        child->m_Height = MAX(child->m_Height, 0);
+        child->m_Width = std::max(child->m_Width, 0);
+        child->m_Height = std::max(child->m_Height, 0);
 
-        int Z = 0;
+        int Zpos = 0;
         // Get the last child in the list
         if (m_Children.size() > 0) {
-            GUIPanel *p = (GUIPanel *)m_Children.at(m_Children.size()-1);
-            Z = p->GetZPos()+1;
+			GUIPanel *lastChild = m_Children.back();
+			Zpos = lastChild->GetZPos() + 1;
         }
 
         // Remove the child from any previous parent
-        if (child->GetParentPanel())
-            child->GetParentPanel()->GUIPanel::RemoveChild(child);
+		if (child->GetParentPanel()) {
+			child->GetParentPanel()->GUIPanel::RemoveChild(child);
+		}
 
         // Setup the inherited values
         child->m_Parent = this;
-        child->Setup(m_Manager, Z);
+        child->Setup(m_Manager, Zpos);
 
         // Add the child to the list
         m_Children.push_back(child);

--- a/Menus/MainMenuGUI.cpp
+++ b/Menus/MainMenuGUI.cpp
@@ -195,10 +195,9 @@ int MainMenuGUI::Create(Controller *pController)
     m_apScreenBox[QUITSCREEN] = dynamic_cast<GUICollectionBox *>(m_pGUIController->GetControl("QuitConfirmBox"));
     m_apScreenBox[MODMANAGERSCREEN] = dynamic_cast<GUICollectionBox *>(m_pGUIController->GetControl("ModManagerScreen"));
 
-	GUICollectionBox *pRootBox = m_apScreenBox[ROOT];
-    pRootBox->SetPositionAbs((g_FrameMan.GetResX() - pRootBox->GetWidth()) / 2, 0);// (g_FrameMan.GetResY() - pRootBox->GetHeight()) / 2);
+	m_apScreenBox[ROOT]->SetPositionAbs((g_FrameMan.GetResX() - m_apScreenBox[ROOT]->GetWidth()) / 2, 0);// (g_FrameMan.GetResY() - m_apScreenBox[ROOT]->GetHeight()) / 2);
 // NO, this screws up the menu positioning!
-//    pRootBox->Resize(pRootBox->GetWidth(), g_FrameMan.GetResY());
+//    m_apScreenBox[ROOT]->Resize(m_apScreenBox[ROOT]->GetWidth(), g_FrameMan.GetResY());
 
     // Set up screens' initial positions and visibility
     m_apScreenBox[QUITSCREEN]->CenterInParent(true, true);

--- a/Menus/MainMenuGUI.cpp
+++ b/Menus/MainMenuGUI.cpp
@@ -533,7 +533,7 @@ int MainMenuGUI::Create(Controller *pController)
 	}
 
     // Read all the credits from the file and set the credits label
-    GUILabel *pCreditsLabel = dynamic_cast<GUILabel *>(m_pGUIController->GetControl("CreditsLabel"));
+	m_CreditsLabel = dynamic_cast<GUILabel *>(m_pGUIController->GetControl("CreditsLabel"));
     Reader creditsReader("Credits.txt");
     string creditsText = creditsReader.ReadTo('#', true);
 
@@ -548,8 +548,8 @@ int MainMenuGUI::Create(Controller *pController)
         if (*sItr == -87)//'©')
             (*sItr) = (char)221;
     }
-    pCreditsLabel->SetText(creditsText);
-    m_pScrollPanel->Resize(m_pScrollPanel->GetWidth(), pCreditsLabel->ResizeHeightToFit());
+	m_CreditsLabel->SetText(creditsText);
+	m_CreditsLabel->ResizeHeightToFit();
 
     // Set initial focus, category list, and label settings
     m_ScreenChange = true;
@@ -827,21 +827,20 @@ void MainMenuGUI::Update()
 			m_MainMenuButtons[BACKTOMAIN]->SetVisible(true);
 			m_apScreenBox[CREDITSSCREEN]->GUIPanel::AddChild(m_MainMenuButtons[BACKTOMAIN]);
 			m_MainMenuButtons[BACKTOMAIN]->SetPositionRel(240, 298);
-			// Set the scroll panel to be out of sight at the bottom of the credits screen box
-			m_pScrollPanel->SetPositionRel(0, m_apScreenBox[CREDITSSCREEN]->GetHeight());
+			m_pScrollPanel->SetPositionRel(0, 0);
+			m_CreditsLabel->SetPositionRel(0, m_pScrollPanel->GetHeight());
 			m_ScrollTimer.Reset();
 			m_ScreenChange = false;
 		}
 
-        long scrollTime = 180000;
+        long scrollTime = 90000;
         float scrollProgress = (float)m_ScrollTimer.GetElapsedRealTimeMS() / (float)scrollTime;
-        int scrollDist = -m_apScreenBox[CREDITSSCREEN]->GetHeight() + (-m_pScrollPanel->GetHeight());
-        // Scroll the scroll panel upwards, GetYPos returns absolute coordinates
-        m_pScrollPanel->SetPositionRel(0, m_apScreenBox[CREDITSSCREEN]->GetHeight() + (scrollDist * scrollProgress));
+        int scrollDist = m_pScrollPanel->GetHeight() + m_CreditsLabel->GetHeight();
+		m_CreditsLabel->SetPositionRel(0, m_pScrollPanel->GetHeight() - static_cast<int>(static_cast<float>(scrollDist) * scrollProgress));
         // If we've scrolled through the whole thing, reset to the bottom and restart scroll
         if (m_ScrollTimer.IsPastRealMS(scrollTime))
         {
-            m_pScrollPanel->SetPositionRel(0, m_apScreenBox[CREDITSSCREEN]->GetHeight());
+			m_CreditsLabel->SetPositionRel(0, m_pScrollPanel->GetHeight());
             m_ScrollTimer.Reset();
         }
 

--- a/Menus/MainMenuGUI.cpp
+++ b/Menus/MainMenuGUI.cpp
@@ -195,15 +195,13 @@ int MainMenuGUI::Create(Controller *pController)
     m_apScreenBox[QUITSCREEN] = dynamic_cast<GUICollectionBox *>(m_pGUIController->GetControl("QuitConfirmBox"));
     m_apScreenBox[MODMANAGERSCREEN] = dynamic_cast<GUICollectionBox *>(m_pGUIController->GetControl("ModManagerScreen"));
 
-	m_apScreenBox[ROOT]->Resize(g_FrameMan.GetResX(), g_FrameMan.GetResY());
+	GUICollectionBox *pRootBox = m_apScreenBox[ROOT];
+    pRootBox->SetPositionAbs((g_FrameMan.GetResX() - pRootBox->GetWidth()) / 2, 0);// (g_FrameMan.GetResY() - pRootBox->GetHeight()) / 2);
+// NO, this screws up the menu positioning!
+//    pRootBox->Resize(pRootBox->GetWidth(), g_FrameMan.GetResY());
 
-	for (int iscreen = MAINSCREEN; iscreen < SCREENCOUNT; ++iscreen)
-	{
-		if (m_apScreenBox[iscreen]) {
-			m_apScreenBox[iscreen]->CenterInParent(true, true);
-		}
-	}
-
+    // Set up screens' initial positions and visibility
+    m_apScreenBox[QUITSCREEN]->CenterInParent(true, true);
     // Hide all screens, the appropriate screen will reappear on next update
     HideAllScreens();
 

--- a/Menus/MainMenuGUI.cpp
+++ b/Menus/MainMenuGUI.cpp
@@ -441,6 +441,7 @@ int MainMenuGUI::Create(Controller *pController)
 
 	m_VersionLabel = dynamic_cast<GUILabel *>(m_pGUIController->GetControl("VersionLabel"));
 	m_VersionLabel->SetText(c_GameVersion);
+	m_VersionLabel->SetPositionAbs(10, g_FrameMan.GetResY() - m_VersionLabel->GetTextHeight() - 10);
 
 	///////////////////////////////////////////////////////////////////////////////////////////////
 	// Load mod data and fill the lists

--- a/Menus/MainMenuGUI.cpp
+++ b/Menus/MainMenuGUI.cpp
@@ -195,17 +195,13 @@ int MainMenuGUI::Create(Controller *pController)
     m_apScreenBox[QUITSCREEN] = dynamic_cast<GUICollectionBox *>(m_pGUIController->GetControl("QuitConfirmBox"));
     m_apScreenBox[MODMANAGERSCREEN] = dynamic_cast<GUICollectionBox *>(m_pGUIController->GetControl("ModManagerScreen"));
 
-	//m_apScreenBox[ROOT]->Resize(g_FrameMan.GetResX(), g_FrameMan.GetResY());
-	m_apScreenBox[ROOT]->SetPositionAbs((g_FrameMan.GetResX() - m_apScreenBox[ROOT]->GetWidth()) / 2, 0);// (g_FrameMan.GetResY() - pRootBox->GetHeight()) / 2);
+	GUICollectionBox *pRootBox = m_apScreenBox[ROOT];
+    pRootBox->SetPositionAbs((g_FrameMan.GetResX() - pRootBox->GetWidth()) / 2, 0);// (g_FrameMan.GetResY() - pRootBox->GetHeight()) / 2);
+// NO, this screws up the menu positioning!
+//    pRootBox->Resize(pRootBox->GetWidth(), g_FrameMan.GetResY());
 
-	//for (int iscreen = MAINSCREEN; iscreen < SCREENCOUNT; ++iscreen)
-	//{
-	//	if (m_apScreenBox[iscreen]) {
-	//		m_apScreenBox[iscreen]->CenterInParent(true, true);
-	//	}
-	//}
+    // Set up screens' initial positions and visibility
     m_apScreenBox[QUITSCREEN]->CenterInParent(true, true);
-
     // Hide all screens, the appropriate screen will reappear on next update
     HideAllScreens();
 
@@ -708,17 +704,17 @@ void MainMenuGUI::Update()
     //////////////////////////////////////
     // PLAYERS MENU SCREEN
 
-//    else if (m_MenuScreen == PLAYERSSCREEN)
-//    {
-//        if (m_ScreenChange)
-//        {
-//            m_apScreenBox[PLAYERSSCREEN]->SetVisible(true);
-//            m_MainMenuButtons[BACKTOMAIN]->SetVisible(true);
-//            m_ScreenChange = false;
-//        }
-//
-////        m_MainMenuButtons[BACKTOMAIN]->SetFocus();
-//    }
+    else if (m_MenuScreen == PLAYERSSCREEN)
+    {
+        if (m_ScreenChange)
+        {
+            m_apScreenBox[PLAYERSSCREEN]->SetVisible(true);
+            m_MainMenuButtons[BACKTOMAIN]->SetVisible(true);
+            m_ScreenChange = false;
+        }
+
+//        m_MainMenuButtons[BACKTOMAIN]->SetFocus();
+    }
 
     //////////////////////////////////////
     // SKIRMISH SETUP MENU SCREEN
@@ -1174,31 +1170,31 @@ void MainMenuGUI::Update()
             // PLAYER SCREEN BUTTONS
 			// Player count setting button pressed
 
-			//if (m_MenuScreen == PLAYERSSCREEN && 
-   //             (anEvent.GetControl()->GetName() == "ButtonOnePlayer" ||
-   //              anEvent.GetControl()->GetName() == "ButtonTwoPlayers" ||
-   //              anEvent.GetControl()->GetName() == "ButtonThreePlayers" ||
-   //              anEvent.GetControl()->GetName() == "ButtonFourPlayers"))
-   //         {
-   //             // Hide all screens, the appropriate screen will reappear on next update
-   //             HideAllScreens();
-   //             m_MenuScreen = SKIRMISHSCREEN;
-   //             m_ScreenChange = true;
+			if (m_MenuScreen == PLAYERSSCREEN && 
+                (anEvent.GetControl()->GetName() == "ButtonOnePlayer" ||
+                 anEvent.GetControl()->GetName() == "ButtonTwoPlayers" ||
+                 anEvent.GetControl()->GetName() == "ButtonThreePlayers" ||
+                 anEvent.GetControl()->GetName() == "ButtonFourPlayers"))
+            {
+                // Hide all screens, the appropriate screen will reappear on next update
+                HideAllScreens();
+                m_MenuScreen = SKIRMISHSCREEN;
+                m_ScreenChange = true;
 
-   //             // Set desired player count
-   //             if (anEvent.GetControl()->GetName() == "ButtonOnePlayer")
-   //                 m_StartPlayers = 1;
-   //             else if (anEvent.GetControl()->GetName() == "ButtonTwoPlayers")
-   //                 m_StartPlayers = 2;
-   //             else if (anEvent.GetControl()->GetName() == "ButtonThreePlayers")
-   //                 m_StartPlayers = 3;
-   //             else if (anEvent.GetControl()->GetName() == "ButtonFourPlayers")
-   //                 m_StartPlayers = 4;
-   //             else
-   //                 m_StartPlayers = 0;
+                // Set desired player count
+                if (anEvent.GetControl()->GetName() == "ButtonOnePlayer")
+                    m_StartPlayers = 1;
+                else if (anEvent.GetControl()->GetName() == "ButtonTwoPlayers")
+                    m_StartPlayers = 2;
+                else if (anEvent.GetControl()->GetName() == "ButtonThreePlayers")
+                    m_StartPlayers = 3;
+                else if (anEvent.GetControl()->GetName() == "ButtonFourPlayers")
+                    m_StartPlayers = 4;
+                else
+                    m_StartPlayers = 0;
 
-   //             g_GUISound.ButtonPressSound()->Play();
-   //         }
+                g_GUISound.ButtonPressSound()->Play();
+            }
 
             /////////////////////////////////////////////
             // SKIRMISH SETUP SCREEN BUTTONS

--- a/Menus/MainMenuGUI.cpp
+++ b/Menus/MainMenuGUI.cpp
@@ -195,13 +195,17 @@ int MainMenuGUI::Create(Controller *pController)
     m_apScreenBox[QUITSCREEN] = dynamic_cast<GUICollectionBox *>(m_pGUIController->GetControl("QuitConfirmBox"));
     m_apScreenBox[MODMANAGERSCREEN] = dynamic_cast<GUICollectionBox *>(m_pGUIController->GetControl("ModManagerScreen"));
 
-	GUICollectionBox *pRootBox = m_apScreenBox[ROOT];
-    pRootBox->SetPositionAbs((g_FrameMan.GetResX() - pRootBox->GetWidth()) / 2, 0);// (g_FrameMan.GetResY() - pRootBox->GetHeight()) / 2);
-// NO, this screws up the menu positioning!
-//    pRootBox->Resize(pRootBox->GetWidth(), g_FrameMan.GetResY());
+	//m_apScreenBox[ROOT]->Resize(g_FrameMan.GetResX(), g_FrameMan.GetResY());
+	m_apScreenBox[ROOT]->SetPositionAbs((g_FrameMan.GetResX() - m_apScreenBox[ROOT]->GetWidth()) / 2, 0);// (g_FrameMan.GetResY() - pRootBox->GetHeight()) / 2);
 
-    // Set up screens' initial positions and visibility
+	//for (int iscreen = MAINSCREEN; iscreen < SCREENCOUNT; ++iscreen)
+	//{
+	//	if (m_apScreenBox[iscreen]) {
+	//		m_apScreenBox[iscreen]->CenterInParent(true, true);
+	//	}
+	//}
     m_apScreenBox[QUITSCREEN]->CenterInParent(true, true);
+
     // Hide all screens, the appropriate screen will reappear on next update
     HideAllScreens();
 
@@ -706,17 +710,17 @@ void MainMenuGUI::Update()
     //////////////////////////////////////
     // PLAYERS MENU SCREEN
 
-    else if (m_MenuScreen == PLAYERSSCREEN)
-    {
-        if (m_ScreenChange)
-        {
-            m_apScreenBox[PLAYERSSCREEN]->SetVisible(true);
-            m_aMainMenuButton[BACKTOMAIN]->SetVisible(true);
-            m_ScreenChange = false;
-        }
-
-//        m_aMainMenuButton[BACKTOMAIN]->SetFocus();
-    }
+//    else if (m_MenuScreen == PLAYERSSCREEN)
+//    {
+//        if (m_ScreenChange)
+//        {
+//            m_apScreenBox[PLAYERSSCREEN]->SetVisible(true);
+//            m_aMainMenuButton[BACKTOMAIN]->SetVisible(true);
+//            m_ScreenChange = false;
+//        }
+//
+////        m_aMainMenuButton[BACKTOMAIN]->SetFocus();
+//    }
 
     //////////////////////////////////////
     // SKIRMISH SETUP MENU SCREEN
@@ -1171,31 +1175,31 @@ void MainMenuGUI::Update()
             // PLAYER SCREEN BUTTONS
 			// Player count setting button pressed
 
-			if (m_MenuScreen == PLAYERSSCREEN && 
-                (anEvent.GetControl()->GetName() == "ButtonOnePlayer" ||
-                 anEvent.GetControl()->GetName() == "ButtonTwoPlayers" ||
-                 anEvent.GetControl()->GetName() == "ButtonThreePlayers" ||
-                 anEvent.GetControl()->GetName() == "ButtonFourPlayers"))
-            {
-                // Hide all screens, the appropriate screen will reappear on next update
-                HideAllScreens();
-                m_MenuScreen = SKIRMISHSCREEN;
-                m_ScreenChange = true;
+			//if (m_MenuScreen == PLAYERSSCREEN && 
+   //             (anEvent.GetControl()->GetName() == "ButtonOnePlayer" ||
+   //              anEvent.GetControl()->GetName() == "ButtonTwoPlayers" ||
+   //              anEvent.GetControl()->GetName() == "ButtonThreePlayers" ||
+   //              anEvent.GetControl()->GetName() == "ButtonFourPlayers"))
+   //         {
+   //             // Hide all screens, the appropriate screen will reappear on next update
+   //             HideAllScreens();
+   //             m_MenuScreen = SKIRMISHSCREEN;
+   //             m_ScreenChange = true;
 
-                // Set desired player count
-                if (anEvent.GetControl()->GetName() == "ButtonOnePlayer")
-                    m_StartPlayers = 1;
-                else if (anEvent.GetControl()->GetName() == "ButtonTwoPlayers")
-                    m_StartPlayers = 2;
-                else if (anEvent.GetControl()->GetName() == "ButtonThreePlayers")
-                    m_StartPlayers = 3;
-                else if (anEvent.GetControl()->GetName() == "ButtonFourPlayers")
-                    m_StartPlayers = 4;
-                else
-                    m_StartPlayers = 0;
+   //             // Set desired player count
+   //             if (anEvent.GetControl()->GetName() == "ButtonOnePlayer")
+   //                 m_StartPlayers = 1;
+   //             else if (anEvent.GetControl()->GetName() == "ButtonTwoPlayers")
+   //                 m_StartPlayers = 2;
+   //             else if (anEvent.GetControl()->GetName() == "ButtonThreePlayers")
+   //                 m_StartPlayers = 3;
+   //             else if (anEvent.GetControl()->GetName() == "ButtonFourPlayers")
+   //                 m_StartPlayers = 4;
+   //             else
+   //                 m_StartPlayers = 0;
 
-                g_GUISound.ButtonPressSound()->Play();
-            }
+   //             g_GUISound.ButtonPressSound()->Play();
+   //         }
 
             /////////////////////////////////////////////
             // SKIRMISH SETUP SCREEN BUTTONS

--- a/Menus/MainMenuGUI.cpp
+++ b/Menus/MainMenuGUI.cpp
@@ -195,13 +195,15 @@ int MainMenuGUI::Create(Controller *pController)
     m_apScreenBox[QUITSCREEN] = dynamic_cast<GUICollectionBox *>(m_pGUIController->GetControl("QuitConfirmBox"));
     m_apScreenBox[MODMANAGERSCREEN] = dynamic_cast<GUICollectionBox *>(m_pGUIController->GetControl("ModManagerScreen"));
 
-	GUICollectionBox *pRootBox = m_apScreenBox[ROOT];
-    pRootBox->SetPositionAbs((g_FrameMan.GetResX() - pRootBox->GetWidth()) / 2, 0);// (g_FrameMan.GetResY() - pRootBox->GetHeight()) / 2);
-// NO, this screws up the menu positioning!
-//    pRootBox->Resize(pRootBox->GetWidth(), g_FrameMan.GetResY());
+	m_apScreenBox[ROOT]->Resize(g_FrameMan.GetResX(), g_FrameMan.GetResY());
 
-    // Set up screens' initial positions and visibility
-    m_apScreenBox[QUITSCREEN]->CenterInParent(true, true);
+	for (int iscreen = MAINSCREEN; iscreen < SCREENCOUNT; ++iscreen)
+	{
+		if (m_apScreenBox[iscreen]) {
+			m_apScreenBox[iscreen]->CenterInParent(true, true);
+		}
+	}
+
     // Hide all screens, the appropriate screen will reappear on next update
     HideAllScreens();
 

--- a/Menus/MainMenuGUI.cpp
+++ b/Menus/MainMenuGUI.cpp
@@ -438,6 +438,9 @@ int MainMenuGUI::Create(Controller *pController)
 		m_aOptionButton[FULLSCREENORWINDOWED]->SetText("Fullscreen");
 	}
 
+	m_VersionLabel = dynamic_cast<GUILabel *>(m_pGUIController->GetControl("VersionLabel"));
+	m_VersionLabel->SetText(c_GameVersion);
+
 	///////////////////////////////////////////////////////////////////////////////////////////////
 	// Load mod data and fill the lists
     for (int i = 0; i < g_PresetMan.GetTotalModuleCount(); ++i)  

--- a/Menus/MainMenuGUI.cpp
+++ b/Menus/MainMenuGUI.cpp
@@ -182,7 +182,7 @@ int MainMenuGUI::Create(Controller *pController)
     m_pGUIController->Load("Base.rte/GUIs/MainMenuGUI.ini");
 
     // Make sure we have convenient points to the containing GUI colleciton boxes that we will manipulate the positions of
-    GUICollectionBox *pRootBox = dynamic_cast<GUICollectionBox *>(m_pGUIController->GetControl("root"));
+	m_apScreenBox[ROOT] = dynamic_cast<GUICollectionBox *>(m_pGUIController->GetControl("root"));
     m_apScreenBox[MAINSCREEN] = dynamic_cast<GUICollectionBox *>(m_pGUIController->GetControl("MainScreen"));
     m_apScreenBox[PLAYERSSCREEN] = dynamic_cast<GUICollectionBox *>(m_pGUIController->GetControl("PlayersScreen"));
     m_apScreenBox[SKIRMISHSCREEN] = dynamic_cast<GUICollectionBox *>(m_pGUIController->GetControl("SkirmishScreen"));
@@ -195,6 +195,7 @@ int MainMenuGUI::Create(Controller *pController)
     m_apScreenBox[QUITSCREEN] = dynamic_cast<GUICollectionBox *>(m_pGUIController->GetControl("QuitConfirmBox"));
     m_apScreenBox[MODMANAGERSCREEN] = dynamic_cast<GUICollectionBox *>(m_pGUIController->GetControl("ModManagerScreen"));
 
+	GUICollectionBox *pRootBox = m_apScreenBox[ROOT];
     pRootBox->SetPositionAbs((g_FrameMan.GetResX() - pRootBox->GetWidth()) / 2, 0);// (g_FrameMan.GetResY() - pRootBox->GetHeight()) / 2);
 // NO, this screws up the menu positioning!
 //    pRootBox->Resize(pRootBox->GetWidth(), g_FrameMan.GetResY());
@@ -1848,7 +1849,7 @@ void MainMenuGUI::Draw(BITMAP *drawBitmap) const
 
 void MainMenuGUI::HideAllScreens()
 {
-    for (int iscreen = 0; iscreen < SCREENCOUNT; ++iscreen)
+    for (int iscreen = MAINSCREEN; iscreen < SCREENCOUNT; ++iscreen)
     {
         if (m_apScreenBox[iscreen])
             m_apScreenBox[iscreen]->SetVisible(false);

--- a/Menus/MainMenuGUI.cpp
+++ b/Menus/MainMenuGUI.cpp
@@ -674,8 +674,6 @@ void MainMenuGUI::Update()
             m_MainMenuButtons[BACKTOMAIN]->SetVisible(false);
             m_MainMenuButtons[PLAYTUTORIAL]->SetVisible(false);
             m_MainMenuButtons[METACONTINUE]->SetVisible(false);
-            // Move main menu button back to center
-            m_MainMenuButtons[BACKTOMAIN]->SetPositionRel(260, 320);
             m_ScreenChange = false;
         }
     
@@ -735,7 +733,7 @@ void MainMenuGUI::Update()
 //            m_pGUIController->GetControl("ButtonStartSkirmish")->SetVisible(true);
             UpdateTeamBoxes();
             // Move main menu button over so the start button fits
-            m_MainMenuButtons[BACKTOMAIN]->SetPositionRel(200, 280);
+			m_MainMenuButtons[BACKTOMAIN]->SetPositionRel(200, 280);
             m_MainMenuButtons[BACKTOMAIN]->SetVisible(true);
             m_ScreenChange = false;
         }
@@ -770,7 +768,8 @@ void MainMenuGUI::Update()
         {
             m_apScreenBox[OPTIONSSCREEN]->SetVisible(true);
             m_MainMenuButtons[BACKTOMAIN]->SetVisible(true);
-			m_MainMenuButtons[BACKTOMAIN]->SetPositionRel(260, 360);
+			m_apScreenBox[OPTIONSSCREEN]->GUIPanel::AddChild(m_MainMenuButtons[BACKTOMAIN]);
+			m_MainMenuButtons[BACKTOMAIN]->SetPositionRel(180, 220);
             m_pBackToOptionsButton->SetVisible(false);
             UpdateDeviceLabels();
             m_ScreenChange = false;
@@ -813,7 +812,8 @@ void MainMenuGUI::Update()
 		if (m_ScreenChange) {
 			m_apScreenBox[EDITORSCREEN]->SetVisible(true);
 			m_MainMenuButtons[BACKTOMAIN]->SetVisible(true);
-			m_MainMenuButtons[BACKTOMAIN]->SetPositionRel(260, 285);
+			m_apScreenBox[EDITORSCREEN]->GUIPanel::AddChild(m_MainMenuButtons[BACKTOMAIN]);
+			m_MainMenuButtons[BACKTOMAIN]->SetPositionRel(4, 145);
 			m_ScreenChange = false;
 		}
 	}
@@ -825,7 +825,8 @@ void MainMenuGUI::Update()
 		if (m_ScreenChange) {
 			m_apScreenBox[CREDITSSCREEN]->SetVisible(true);
 			m_MainMenuButtons[BACKTOMAIN]->SetVisible(true);
-			m_MainMenuButtons[BACKTOMAIN]->SetPositionRel(260, 430);
+			m_apScreenBox[CREDITSSCREEN]->GUIPanel::AddChild(m_MainMenuButtons[BACKTOMAIN]);
+			m_MainMenuButtons[BACKTOMAIN]->SetPositionRel(240, 298);
 			// Set the scroll panel to be out of sight at the bottom of the credits screen box
 			m_pScrollPanel->SetPositionRel(0, m_apScreenBox[CREDITSSCREEN]->GetHeight());
 			m_ScrollTimer.Reset();
@@ -1139,7 +1140,6 @@ void MainMenuGUI::Update()
                 // Hide all screens, the appropriate screen will reappear on next update
                 HideAllScreens();
                 m_MainMenuButtons[BACKTOMAIN]->SetVisible(false);
-                m_MainMenuButtons[BACKTOMAIN]->SetPositionRel(260, 280);
 
                 // If leaving the options screen, save the settings!
                 if (m_MenuScreen == OPTIONSSCREEN)
@@ -1241,8 +1241,6 @@ void MainMenuGUI::Update()
                     // CPU team present, so ask for the difficulty level of it before starting
                     else
                     {
-                        // Move main menu button back to center
-                        m_MainMenuButtons[BACKTOMAIN]->SetPositionRel(260, 280);
                         m_MenuScreen = DIFFICULTYSCREEN;
                         m_ScreenChange = true;
                         g_GUISound.ButtonPressSound()->Play();

--- a/Menus/MainMenuGUI.cpp
+++ b/Menus/MainMenuGUI.cpp
@@ -84,7 +84,7 @@ void MainMenuGUI::Clear()
     for (int screen = 0; screen < SCREENCOUNT; ++screen)
         m_apScreenBox[screen] = 0;
     for (int button = 0; button < MAINMENUBUTTONCOUNT; ++button)
-        m_aMainMenuButton[button] = 0;
+        m_MainMenuButtons[button] = 0;
     m_pTeamBox = 0;
     m_pSceneSelector = 0;
     for (int box = 0; box < SKIRMISHPLAYERCOUNT; ++box)
@@ -214,23 +214,23 @@ int MainMenuGUI::Create(Controller *pController)
     // Credits scrolling panel
     m_pScrollPanel = dynamic_cast<GUICollectionBox *>(m_pGUIController->GetControl("CreditsPanel"));
 
-    m_aMainMenuButton[CAMPAIGN] = dynamic_cast<GUIButton *>(m_pGUIController->GetControl("ButtonMainToCampaign"));
-    m_aMainMenuButton[SKIRMISH] = dynamic_cast<GUIButton *>(m_pGUIController->GetControl("ButtonMainToSkirmish"));
-	m_aMainMenuButton[MULTIPLAYER] = dynamic_cast<GUIButton *>(m_pGUIController->GetControl("ButtonMainToMultiplayer"));
-	m_aMainMenuButton[OPTIONS] = dynamic_cast<GUIButton *>(m_pGUIController->GetControl("ButtonMainToOptions"));
-    m_aMainMenuButton[MODMANAGER] = dynamic_cast<GUIButton *>(m_pGUIController->GetControl("ButtonMainToModManager"));
-    m_aMainMenuButton[EDITOR] = dynamic_cast<GUIButton *>(m_pGUIController->GetControl("ButtonMainToEditor"));
-    m_aMainMenuButton[CREDITS] = dynamic_cast<GUIButton *>(m_pGUIController->GetControl("ButtonMainToCreds"));
-    m_aMainMenuButton[QUIT] = dynamic_cast<GUIButton *>(m_pGUIController->GetControl("ButtonQuit"));
-    m_aMainMenuButton[RESUME] = dynamic_cast<GUIButton *>(m_pGUIController->GetControl("ButtonResume"));
-    m_aMainMenuButton[PLAYTUTORIAL] = dynamic_cast<GUIButton *>(m_pGUIController->GetControl("ButtonTutorial"));
-    m_aMainMenuButton[METACONTINUE] = dynamic_cast<GUIButton *>(m_pGUIController->GetControl("ButtonContinue"));
-    m_aMainMenuButton[BACKTOMAIN] = dynamic_cast<GUIButton *>(m_pGUIController->GetControl("ButtonBackToMain"));
-    m_aMainMenuButton[QUITCONFIRM] = dynamic_cast<GUIButton *>(m_pGUIController->GetControl("QuitConfirmButton"));
-    m_aMainMenuButton[QUITCANCEL] = dynamic_cast<GUIButton *>(m_pGUIController->GetControl("QuitCancelButton"));
-    m_aMainMenuButton[BACKTOMAIN]->SetVisible(false);
-    m_aMainMenuButton[PLAYTUTORIAL]->SetVisible(false);
-    m_aMainMenuButton[METACONTINUE]->SetVisible(false);
+    m_MainMenuButtons[CAMPAIGN] = dynamic_cast<GUIButton *>(m_pGUIController->GetControl("ButtonMainToCampaign"));
+    m_MainMenuButtons[SKIRMISH] = dynamic_cast<GUIButton *>(m_pGUIController->GetControl("ButtonMainToSkirmish"));
+	m_MainMenuButtons[MULTIPLAYER] = dynamic_cast<GUIButton *>(m_pGUIController->GetControl("ButtonMainToMultiplayer"));
+	m_MainMenuButtons[OPTIONS] = dynamic_cast<GUIButton *>(m_pGUIController->GetControl("ButtonMainToOptions"));
+    m_MainMenuButtons[MODMANAGER] = dynamic_cast<GUIButton *>(m_pGUIController->GetControl("ButtonMainToModManager"));
+    m_MainMenuButtons[EDITOR] = dynamic_cast<GUIButton *>(m_pGUIController->GetControl("ButtonMainToEditor"));
+    m_MainMenuButtons[CREDITS] = dynamic_cast<GUIButton *>(m_pGUIController->GetControl("ButtonMainToCreds"));
+    m_MainMenuButtons[QUIT] = dynamic_cast<GUIButton *>(m_pGUIController->GetControl("ButtonQuit"));
+    m_MainMenuButtons[RESUME] = dynamic_cast<GUIButton *>(m_pGUIController->GetControl("ButtonResume"));
+    m_MainMenuButtons[PLAYTUTORIAL] = dynamic_cast<GUIButton *>(m_pGUIController->GetControl("ButtonTutorial"));
+    m_MainMenuButtons[METACONTINUE] = dynamic_cast<GUIButton *>(m_pGUIController->GetControl("ButtonContinue"));
+    m_MainMenuButtons[BACKTOMAIN] = dynamic_cast<GUIButton *>(m_pGUIController->GetControl("ButtonBackToMain"));
+    m_MainMenuButtons[QUITCONFIRM] = dynamic_cast<GUIButton *>(m_pGUIController->GetControl("QuitConfirmButton"));
+    m_MainMenuButtons[QUITCANCEL] = dynamic_cast<GUIButton *>(m_pGUIController->GetControl("QuitCancelButton"));
+    m_MainMenuButtons[BACKTOMAIN]->SetVisible(false);
+    m_MainMenuButtons[PLAYTUTORIAL]->SetVisible(false);
+    m_MainMenuButtons[METACONTINUE]->SetVisible(false);
 
     m_pSceneSelector = dynamic_cast<GUIComboBox *>(m_pGUIController->GetControl("ComboScene"));
     m_pTeamBox = dynamic_cast<GUICollectionBox *>(m_pGUIController->GetControl("PanelTeams"));
@@ -661,29 +661,29 @@ void MainMenuGUI::Update()
             if (g_ActivityMan.GetActivity() && (g_ActivityMan.GetActivity()->GetActivityState() == Activity::Running || g_ActivityMan.GetActivity()->GetActivityState() == Activity::Editing))
             {
                 m_apScreenBox[MAINSCREEN]->Resize(128, 220);
-                m_aMainMenuButton[RESUME]->SetVisible(true);
+                m_MainMenuButtons[RESUME]->SetVisible(true);
             }
             else
             {
                 m_apScreenBox[MAINSCREEN]->Resize(128, 196);
-                m_aMainMenuButton[RESUME]->SetVisible(false);
+                m_MainMenuButtons[RESUME]->SetVisible(false);
             }
             // Restore the label on the campaign button
-            m_aMainMenuButton[CAMPAIGN]->SetText("Metagame (WIP)");
+            m_MainMenuButtons[CAMPAIGN]->SetText("Metagame (WIP)");
 
-            m_aMainMenuButton[BACKTOMAIN]->SetVisible(false);
-            m_aMainMenuButton[PLAYTUTORIAL]->SetVisible(false);
-            m_aMainMenuButton[METACONTINUE]->SetVisible(false);
+            m_MainMenuButtons[BACKTOMAIN]->SetVisible(false);
+            m_MainMenuButtons[PLAYTUTORIAL]->SetVisible(false);
+            m_MainMenuButtons[METACONTINUE]->SetVisible(false);
             // Move main menu button back to center
-            m_aMainMenuButton[BACKTOMAIN]->SetPositionRel(260, 320);
+            m_MainMenuButtons[BACKTOMAIN]->SetPositionRel(260, 320);
             m_ScreenChange = false;
         }
     
         // Blink the resume button to show the game is still going
-        if (m_aMainMenuButton[RESUME]->GetVisible())
+        if (m_MainMenuButtons[RESUME]->GetVisible())
         {
             if (m_BlinkTimer.AlternateReal(500))
-                m_aMainMenuButton[RESUME]->SetFocus();
+                m_MainMenuButtons[RESUME]->SetFocus();
             else
                 m_pGUIController->GetManager()->SetFocus(0);
         }
@@ -715,11 +715,11 @@ void MainMenuGUI::Update()
 //        if (m_ScreenChange)
 //        {
 //            m_apScreenBox[PLAYERSSCREEN]->SetVisible(true);
-//            m_aMainMenuButton[BACKTOMAIN]->SetVisible(true);
+//            m_MainMenuButtons[BACKTOMAIN]->SetVisible(true);
 //            m_ScreenChange = false;
 //        }
 //
-////        m_aMainMenuButton[BACKTOMAIN]->SetFocus();
+////        m_MainMenuButtons[BACKTOMAIN]->SetFocus();
 //    }
 
     //////////////////////////////////////
@@ -735,15 +735,15 @@ void MainMenuGUI::Update()
 //            m_pGUIController->GetControl("ButtonStartSkirmish")->SetVisible(true);
             UpdateTeamBoxes();
             // Move main menu button over so the start button fits
-            m_aMainMenuButton[BACKTOMAIN]->SetPositionRel(200, 280);
-            m_aMainMenuButton[BACKTOMAIN]->SetVisible(true);
+            m_MainMenuButtons[BACKTOMAIN]->SetPositionRel(200, 280);
+            m_MainMenuButtons[BACKTOMAIN]->SetVisible(true);
             m_ScreenChange = false;
         }
 
 //        for (int box = 0; box < SKIRMISHPLAYERCOUNT; ++box)
 //            m_aSkirmishBox[box] = 0;
 
-//        m_aMainMenuButton[BACKTOMAIN]->SetFocus();
+//        m_MainMenuButtons[BACKTOMAIN]->SetFocus();
     }
 
 	//////////////////////////////////////
@@ -754,11 +754,11 @@ void MainMenuGUI::Update()
         if (m_ScreenChange)
         {
             m_apScreenBox[DIFFICULTYSCREEN]->SetVisible(true);
-            m_aMainMenuButton[BACKTOMAIN]->SetVisible(true);
+            m_MainMenuButtons[BACKTOMAIN]->SetVisible(true);
             m_ScreenChange = false;
         }
 
-//        m_aMainMenuButton[BACKTOMAIN]->SetFocus();
+//        m_MainMenuButtons[BACKTOMAIN]->SetFocus();
     }
 
     //////////////////////////////////////
@@ -769,8 +769,8 @@ void MainMenuGUI::Update()
         if (m_ScreenChange)
         {
             m_apScreenBox[OPTIONSSCREEN]->SetVisible(true);
-            m_aMainMenuButton[BACKTOMAIN]->SetVisible(true);
-			m_aMainMenuButton[BACKTOMAIN]->SetPositionRel(260, 360);
+            m_MainMenuButtons[BACKTOMAIN]->SetVisible(true);
+			m_MainMenuButtons[BACKTOMAIN]->SetPositionRel(260, 360);
             m_pBackToOptionsButton->SetVisible(false);
             UpdateDeviceLabels();
             m_ScreenChange = false;
@@ -785,7 +785,7 @@ void MainMenuGUI::Update()
         if (m_ScreenChange)
         {
             m_apScreenBox[CONFIGSCREEN]->SetVisible(true);
-            m_aMainMenuButton[BACKTOMAIN]->SetVisible(false);
+            m_MainMenuButtons[BACKTOMAIN]->SetVisible(false);
             m_pBackToOptionsButton->SetVisible(true);
             // Let this pass through, UpdateConfigScreen uses it
             //m_ScreenChange = false;
@@ -812,8 +812,8 @@ void MainMenuGUI::Update()
 	else if (m_MenuScreen == EDITORSCREEN) {
 		if (m_ScreenChange) {
 			m_apScreenBox[EDITORSCREEN]->SetVisible(true);
-			m_aMainMenuButton[BACKTOMAIN]->SetVisible(true);
-			m_aMainMenuButton[BACKTOMAIN]->SetPositionRel(260, 285);
+			m_MainMenuButtons[BACKTOMAIN]->SetVisible(true);
+			m_MainMenuButtons[BACKTOMAIN]->SetPositionRel(260, 285);
 			m_ScreenChange = false;
 		}
 	}
@@ -824,8 +824,8 @@ void MainMenuGUI::Update()
 	else if (m_MenuScreen == CREDITSSCREEN) {
 		if (m_ScreenChange) {
 			m_apScreenBox[CREDITSSCREEN]->SetVisible(true);
-			m_aMainMenuButton[BACKTOMAIN]->SetVisible(true);
-			m_aMainMenuButton[BACKTOMAIN]->SetPositionRel(260, 430);
+			m_MainMenuButtons[BACKTOMAIN]->SetVisible(true);
+			m_MainMenuButtons[BACKTOMAIN]->SetPositionRel(260, 430);
 			// Set the scroll panel to be out of sight at the bottom of the credits screen box
 			m_pScrollPanel->SetPositionRel(0, m_apScreenBox[CREDITSSCREEN]->GetHeight());
 			m_ScrollTimer.Reset();
@@ -844,7 +844,7 @@ void MainMenuGUI::Update()
             m_ScrollTimer.Reset();
         }
 
-//        m_aMainMenuButton[BACKTOMAIN]->SetFocus();
+//        m_MainMenuButtons[BACKTOMAIN]->SetFocus();
     }
 
     //////////////////////////////////////
@@ -855,8 +855,8 @@ void MainMenuGUI::Update()
         if (m_ScreenChange)
         {
             m_apScreenBox[METASCREEN]->SetVisible(true);
-            m_aMainMenuButton[PLAYTUTORIAL]->SetVisible(true);
-            m_aMainMenuButton[METACONTINUE]->SetVisible(true);
+            m_MainMenuButtons[PLAYTUTORIAL]->SetVisible(true);
+            m_MainMenuButtons[METACONTINUE]->SetVisible(true);
             m_pMetaNoticeLabel->SetText("- A T T E N T I O N -\n\nPlease note that the Campaign is in an INCOMPLETE, fully playable, yet still imperfect state!\nAs such, it is lacking some polish, audio, and game balancing, and we will be upgrading it significantly in future.\nThat said, you can absolutely enjoy fighting the A.I. and/or up to three friends in co-op, 2 vs 2, etc.\n\nAlso, if you have not yet played Cortex Command, we recommend you first try the tutorial:");
             m_pMetaNoticeLabel->SetVisible(true);
             // Flag that this notice has now been shown once, so no need to keep showing it
@@ -864,7 +864,7 @@ void MainMenuGUI::Update()
             m_ScreenChange = false;
         }
 
-//        m_aMainMenuButton[BACKTOMAIN]->SetFocus();
+//        m_MainMenuButtons[BACKTOMAIN]->SetFocus();
     }
 
     //////////////////////////////////////
@@ -878,7 +878,7 @@ void MainMenuGUI::Update()
             m_ScreenChange = false;
         }
 
-//        m_aMainMenuButton[QUITCONFIRM]->SetFocus();
+//        m_MainMenuButtons[QUITCONFIRM]->SetFocus();
     }
 
     //////////////////////////////////////////
@@ -896,18 +896,18 @@ void MainMenuGUI::Update()
 		if (anEvent.GetType() == GUIEvent::Command)
         {
 			// Campaign button pressed
-			if (anEvent.GetControl() == m_aMainMenuButton[CAMPAIGN])
+			if (anEvent.GetControl() == m_MainMenuButtons[CAMPAIGN])
             {
 /*
                 // Disable the campaign button for now
-                if (m_aMainMenuButton[CAMPAIGN]->GetText() == "Campaign")
+                if (m_MainMenuButtons[CAMPAIGN]->GetText() == "Campaign")
                 {
-                    m_aMainMenuButton[CAMPAIGN]->SetText("COMING SOON!");
+                    m_MainMenuButtons[CAMPAIGN]->SetText("COMING SOON!");
                     g_GUISound.ExitMenuSound()->Play();
                 }
                 else
                 {
-                    m_aMainMenuButton[CAMPAIGN]->SetText("Campaign");
+                    m_MainMenuButtons[CAMPAIGN]->SetText("Campaign");
                     g_GUISound.ButtonPressSound()->Play();
                 }
 */
@@ -927,7 +927,7 @@ void MainMenuGUI::Update()
             }
 
 			// Skirmish button pressed
-			if (anEvent.GetControl() == m_aMainMenuButton[SKIRMISH])
+			if (anEvent.GetControl() == m_MainMenuButtons[SKIRMISH])
             {
                 m_ScenarioStarted = true;
                 m_CampaignStarted = false;
@@ -944,7 +944,7 @@ void MainMenuGUI::Update()
 //                g_GUISound.ExitMenuSound()->Play();
             }
 
-			if (anEvent.GetControl() == m_aMainMenuButton[MULTIPLAYER])
+			if (anEvent.GetControl() == m_MainMenuButtons[MULTIPLAYER])
 			{
 				m_ScenarioStarted = true;
 				m_CampaignStarted = false;
@@ -973,7 +973,7 @@ void MainMenuGUI::Update()
 			}
 
 			// Options button pressed
-			if (anEvent.GetControl() == m_aMainMenuButton[OPTIONS])
+			if (anEvent.GetControl() == m_MainMenuButtons[OPTIONS])
             {
                 // Hide all screens, the appropriate screen will reappear on next update
                 HideAllScreens();
@@ -984,7 +984,7 @@ void MainMenuGUI::Update()
             }
 
 			// Editor button pressed
-			if (anEvent.GetControl() == m_aMainMenuButton[EDITOR])
+			if (anEvent.GetControl() == m_MainMenuButtons[EDITOR])
             {
                 m_CampaignStarted = false;
 
@@ -1001,7 +1001,7 @@ void MainMenuGUI::Update()
             }
 
 			// Editor button pressed
-			if (anEvent.GetControl() == m_aMainMenuButton[MODMANAGER])
+			if (anEvent.GetControl() == m_MainMenuButtons[MODMANAGER])
             {
                 // Hide all screens, the appropriate screen will reappear on next update
                 HideAllScreens();
@@ -1012,7 +1012,7 @@ void MainMenuGUI::Update()
             }
 
 			// Credits button pressed
-			if (anEvent.GetControl() == m_aMainMenuButton[CREDITS])
+			if (anEvent.GetControl() == m_MainMenuButtons[CREDITS])
             {
                 // Hide all screens, the appropriate screen will reappear on next update
                 HideAllScreens();
@@ -1023,14 +1023,14 @@ void MainMenuGUI::Update()
             }
 
 			// Quit button pressed
-			if (anEvent.GetControl() == m_aMainMenuButton[QUIT])
+			if (anEvent.GetControl() == m_MainMenuButtons[QUIT])
             {
                 QuitLogic();
                 g_GUISound.ButtonPressSound()->Play();
             }
 
 			// Resume button pressed
-			if (anEvent.GetControl() == m_aMainMenuButton[RESUME])
+			if (anEvent.GetControl() == m_MainMenuButtons[RESUME])
             {
                 m_ActivityResumed = true;
 
@@ -1046,11 +1046,11 @@ void MainMenuGUI::Update()
 						m_ResolutionChangeToUpscaled = false;
 						m_ResolutionChangeDialog->SetVisible(true);
 						m_apScreenBox[OPTIONSSCREEN]->SetEnabled(false);
-						m_aMainMenuButton[BACKTOMAIN]->SetEnabled(false);
+						m_MainMenuButtons[BACKTOMAIN]->SetEnabled(false);
 						m_ButtonConfirmResolutionChangeFullscreen->SetVisible(true);
 					} else {
 						HideAllScreens();
-						m_aMainMenuButton[BACKTOMAIN]->SetVisible(false);
+						m_MainMenuButtons[BACKTOMAIN]->SetVisible(false);
 						g_FrameMan.SwitchToFullscreen(false);
 					}
 				} else if (g_FrameMan.IsFullscreen() && !g_FrameMan.IsUpscaledFullscreen()) {
@@ -1058,11 +1058,11 @@ void MainMenuGUI::Update()
 						m_ResolutionChangeToUpscaled = false;
 						m_ResolutionChangeDialog->SetVisible(true);
 						m_apScreenBox[OPTIONSSCREEN]->SetEnabled(false);
-						m_aMainMenuButton[BACKTOMAIN]->SetEnabled(false);
+						m_MainMenuButtons[BACKTOMAIN]->SetEnabled(false);
 						m_ButtonConfirmResolutionChangeFullscreen->SetVisible(true);
 					} else {
 						HideAllScreens();
-						m_aMainMenuButton[BACKTOMAIN]->SetVisible(false);
+						m_MainMenuButtons[BACKTOMAIN]->SetVisible(false);
 						g_FrameMan.SwitchResolution(960,540);
 					}
 				} else if (!g_FrameMan.IsFullscreen() && g_FrameMan.IsUpscaledFullscreen()) {
@@ -1080,11 +1080,11 @@ void MainMenuGUI::Update()
 						m_ResolutionChangeToUpscaled = true;
 						m_ResolutionChangeDialog->SetVisible(true);
 						m_apScreenBox[OPTIONSSCREEN]->SetEnabled(false);
-						m_aMainMenuButton[BACKTOMAIN]->SetEnabled(false);
+						m_MainMenuButtons[BACKTOMAIN]->SetEnabled(false);
 						m_ButtonConfirmResolutionChangeFullscreen->SetVisible(true);
 					} else {
 						HideAllScreens();
-						m_aMainMenuButton[BACKTOMAIN]->SetVisible(false);
+						m_MainMenuButtons[BACKTOMAIN]->SetVisible(false);
 						g_FrameMan.SwitchToFullscreen(true);
 					}
 				}
@@ -1094,8 +1094,8 @@ void MainMenuGUI::Update()
 			if (anEvent.GetControl() == m_ButtonConfirmResolutionChangeFullscreen) {
 				g_GUISound.ButtonPressSound()->Play();
 				HideAllScreens();
-				m_aMainMenuButton[BACKTOMAIN]->SetVisible(false);
-				m_aMainMenuButton[BACKTOMAIN]->SetEnabled(true);
+				m_MainMenuButtons[BACKTOMAIN]->SetVisible(false);
+				m_MainMenuButtons[BACKTOMAIN]->SetEnabled(true);
 				m_ResolutionChangeDialog->SetVisible(false);
 				m_apScreenBox[OPTIONSSCREEN]->SetEnabled(true);
 				m_ButtonConfirmResolutionChangeFullscreen->SetVisible(false);
@@ -1110,8 +1110,8 @@ void MainMenuGUI::Update()
 			if (anEvent.GetControl() == m_ButtonConfirmResolutionChange) {
 				g_GUISound.ButtonPressSound()->Play();
 				HideAllScreens();
-				m_aMainMenuButton[BACKTOMAIN]->SetVisible(false);
-				m_aMainMenuButton[BACKTOMAIN]->SetEnabled(true);
+				m_MainMenuButtons[BACKTOMAIN]->SetVisible(false);
+				m_MainMenuButtons[BACKTOMAIN]->SetEnabled(true);
 				m_ResolutionChangeDialog->SetVisible(false);
 				m_apScreenBox[OPTIONSSCREEN]->SetEnabled(true);
 				m_ButtonConfirmResolutionChange->SetVisible(false);
@@ -1130,16 +1130,16 @@ void MainMenuGUI::Update()
 				g_GUISound.ButtonPressSound()->Play();
 				m_ResolutionChangeDialog->SetVisible(false);
 				m_apScreenBox[OPTIONSSCREEN]->SetEnabled(true);
-				m_aMainMenuButton[BACKTOMAIN]->SetEnabled(true);
+				m_MainMenuButtons[BACKTOMAIN]->SetEnabled(true);
 			}
 			
 			// Return to main menu button pressed
-			if (anEvent.GetControl() == m_aMainMenuButton[BACKTOMAIN])
+			if (anEvent.GetControl() == m_MainMenuButtons[BACKTOMAIN])
             {
                 // Hide all screens, the appropriate screen will reappear on next update
                 HideAllScreens();
-                m_aMainMenuButton[BACKTOMAIN]->SetVisible(false);
-                m_aMainMenuButton[BACKTOMAIN]->SetPositionRel(260, 280);
+                m_MainMenuButtons[BACKTOMAIN]->SetVisible(false);
+                m_MainMenuButtons[BACKTOMAIN]->SetPositionRel(260, 280);
 
                 // If leaving the options screen, save the settings!
                 if (m_MenuScreen == OPTIONSSCREEN)
@@ -1242,7 +1242,7 @@ void MainMenuGUI::Update()
                     else
                     {
                         // Move main menu button back to center
-                        m_aMainMenuButton[BACKTOMAIN]->SetPositionRel(260, 280);
+                        m_MainMenuButtons[BACKTOMAIN]->SetPositionRel(260, 280);
                         m_MenuScreen = DIFFICULTYSCREEN;
                         m_ScreenChange = true;
                         g_GUISound.ButtonPressSound()->Play();
@@ -1496,7 +1496,7 @@ void MainMenuGUI::Update()
 			if (m_MenuScreen == METASCREEN)
             {
                 // Play tutorial button pressed
-                if (anEvent.GetControl() == m_aMainMenuButton[PLAYTUTORIAL])
+                if (anEvent.GetControl() == m_MainMenuButtons[PLAYTUTORIAL])
                 {
                     // Hide all screens, the appropriate screen will reappear on next update
                     HideAllScreens();
@@ -1514,7 +1514,7 @@ void MainMenuGUI::Update()
                     g_GUISound.ButtonPressSound()->Play();
                 }
                 // Go to registration dialog button
-                else if (anEvent.GetControl() == m_aMainMenuButton[METACONTINUE])
+                else if (anEvent.GetControl() == m_MainMenuButtons[METACONTINUE])
                 {
                     m_CampaignStarted = true;
 
@@ -1563,7 +1563,7 @@ void MainMenuGUI::Update()
 			if (m_MenuScreen == QUITSCREEN)
             {
                 // Confirm quitting of game
-                if (anEvent.GetControl() == m_aMainMenuButton[QUITCONFIRM])
+                if (anEvent.GetControl() == m_MainMenuButtons[QUITCONFIRM])
                 {
                     m_Quit = true;
 
@@ -1574,7 +1574,7 @@ void MainMenuGUI::Update()
                     g_GUISound.ButtonPressSound()->Play();
                 }
                 // Cancel quitting
-                else if (anEvent.GetControl() == m_aMainMenuButton[QUITCANCEL])
+                else if (anEvent.GetControl() == m_MainMenuButtons[QUITCANCEL])
                 {
                     // Hide all screens, the appropriate screen will reappear on next update
                     HideAllScreens();
@@ -1673,7 +1673,7 @@ void MainMenuGUI::Update()
 							m_ButtonConfirmResolutionChange->SetVisible(true);
 						} else {
 							HideAllScreens();
-							m_aMainMenuButton[BACKTOMAIN]->SetVisible(false);
+							m_MainMenuButtons[BACKTOMAIN]->SetVisible(false);
 							g_FrameMan.SwitchResolution(g_FrameMan.GetNewResX(), g_FrameMan.GetNewResY(), 1);
 						}
 					}

--- a/Menus/MainMenuGUI.h
+++ b/Menus/MainMenuGUI.h
@@ -713,6 +713,7 @@ protected:
     GUICollectionBox *m_pEditorPanel;
     // Scrolling panel for the credits
     GUICollectionBox *m_pScrollPanel;
+	GUILabel *m_CreditsLabel; //!< The label containing all the credits text.
     // Timer for credits scrolling pacing
     Timer m_ScrollTimer;
 

--- a/Menus/MainMenuGUI.h
+++ b/Menus/MainMenuGUI.h
@@ -636,7 +636,7 @@ protected:
     // Collection box of the buy GUIs
     GUICollectionBox *m_apScreenBox[SCREENCOUNT];
     // The main menu buttons
-    GUIButton *m_aMainMenuButton[MAINMENUBUTTONCOUNT];
+    GUIButton *m_MainMenuButtons[MAINMENUBUTTONCOUNT];
     // Skirmish scene selction box
     GUIComboBox *m_pSceneSelector;
     // The skirmish setup screen team box panels

--- a/Menus/MainMenuGUI.h
+++ b/Menus/MainMenuGUI.h
@@ -685,6 +685,7 @@ protected:
     GUIButton *m_aEditorButton[EDITORBUTTONCOUNT];
     // Metagame notice label
     GUILabel *m_pMetaNoticeLabel;
+	GUILabel *m_VersionLabel; //!< CCCP version number.
 
     // Controller diagram bitmaps
     BITMAP **m_aDPadBitmaps;

--- a/Menus/MetagameGUI.cpp
+++ b/Menus/MetagameGUI.cpp
@@ -2255,16 +2255,18 @@ void MetagameGUI::UpdateInput()
 	GUIEvent anEvent;
 	while(m_pGUIController->GetEvent(&anEvent))
     {
+		const std::string eventControlName = anEvent.GetControl()->GetName();
+
         // Commands
 		if (anEvent.GetType() == GUIEvent::Command)
         {
 			// Open game menu button pressed
 			// Most big dialog cancel buttons lead back to the game menu too
-			if (anEvent.GetControl()->GetName() == "OpenMenuButton" ||
-                anEvent.GetControl()->GetName() == "SaveCancelButton" ||
-                anEvent.GetControl()->GetName() == "LoadCancelButton" ||
-                anEvent.GetControl()->GetName() == "NewCancelButton" ||
-                anEvent.GetControl()->GetName() == "ConfirmCancelButton")
+			if (eventControlName == "OpenMenuButton" ||
+                eventControlName == "SaveCancelButton" ||
+                eventControlName == "LoadCancelButton" ||
+				(eventControlName == "NewCancelButton" && g_MetaMan.GameInProgress()) ||
+                eventControlName == "ConfirmCancelButton")
             {
                 g_MetaMan.SetSuspend(true);
                 SwitchToScreen(MENUDIALOG);
@@ -2272,7 +2274,7 @@ void MetagameGUI::UpdateInput()
             }
 
 			// Return to main menu button pressed
-			if (anEvent.GetControl()->GetName() == "MainMenuButton")
+			else if (eventControlName == "MainMenuButton" || eventControlName == "NewCancelButton")
             {
 				//Return Metagame dialog to new game state
 				// weegee SwitchToScreen(NEWDIALOG);
@@ -2285,7 +2287,7 @@ void MetagameGUI::UpdateInput()
             }
 
 			// Open save menu button pressed
-			if (anEvent.GetControl()->GetName() == "MenuSaveButton")
+			else if (eventControlName == "MenuSaveButton")
             {
                 g_MetaMan.SetSuspend(true);
                 SwitchToScreen(SAVEDIALOG);
@@ -2293,8 +2295,8 @@ void MetagameGUI::UpdateInput()
             }
 
 			// Open load menu button pressed
-			if (anEvent.GetControl()->GetName() == "MenuLoadButton" ||
-                anEvent.GetControl()->GetName() == "NewLoadButton")
+			else if (eventControlName == "MenuLoadButton" ||
+                eventControlName == "NewLoadButton")
             {
                 g_MetaMan.SetSuspend(true);
                 SwitchToScreen(LOADDIALOG);
@@ -2302,7 +2304,7 @@ void MetagameGUI::UpdateInput()
             }
 
 			// New Game menu button pressed
-			if (anEvent.GetControl()->GetName() == "MenuNewButton")
+			else if (eventControlName == "MenuNewButton")
             {
                 g_MetaMan.SetSuspend(true);
                 SwitchToScreen(NEWDIALOG);
@@ -2311,7 +2313,7 @@ void MetagameGUI::UpdateInput()
             }
 
 			// Quit Program button pressed
-			if (anEvent.GetControl()->GetName() == "MenuQuitButton")
+			else if (eventControlName == "MenuQuitButton")
             {
                 HideAllScreens();
                 g_MetaMan.SetSuspend(true);
@@ -2322,7 +2324,7 @@ void MetagameGUI::UpdateInput()
             }
 
 			// Resume Game menu button pressed
-			if (anEvent.GetControl()->GetName() == "MenuResumeButton")
+			else if (eventControlName == "MenuResumeButton")
             {
                 g_MetaMan.SetSuspend(false);
                 // If game over, then go to new game dialog on resume
@@ -2392,7 +2394,7 @@ void MetagameGUI::UpdateInput()
             }
 
 			// Start New Game menu button pressed
-			if (anEvent.GetControl()->GetName() == "StartButton")
+			if (eventControlName == "StartButton")
             {
                 // Current game needs saved or there will be data loss, so show confirmation box
                 if (!g_MetaMan.GameIsSaved())
@@ -2409,7 +2411,7 @@ void MetagameGUI::UpdateInput()
             }
 
 			// Save game button pressed
-			if (anEvent.GetControl()->GetName() == "SaveButton")
+			if (eventControlName == "SaveButton")
             {
                 // Overwrite confirmation click has been done already
                 if (!m_NewSaveBox->GetText().empty() || m_apMetaButton[SAVENOW]->GetText() != "Save")
@@ -2443,7 +2445,7 @@ void MetagameGUI::UpdateInput()
             }
 
 			// Load game button pressed
-			if (anEvent.GetControl()->GetName() == "LoadButton" && m_pSavesToLoadCombo->GetSelectedItem())
+			if (eventControlName == "LoadButton" && m_pSavesToLoadCombo->GetSelectedItem())
             {
                 // Save this Entity selection because the ComboBox gets cleared out when the conf dlg appears, so we can't get to the selection later when we acutally decide to load the damn thing
                 m_pSelectedGameToLoad = m_pSavesToLoadCombo->GetSelectedItem()->m_pEntity;

--- a/System/Constants.h
+++ b/System/Constants.h
@@ -9,6 +9,10 @@ namespace RTE {
 	typedef int MID; //!< Distinctive type definition for Material IDs.
 #pragma endregion
 
+#pragma region Game Version
+	static constexpr char *c_GameVersion = "Pre-release 3";
+#pragma endregion
+
 #pragma region Filesystem Constants
 	static constexpr char *c_ScreenshotDirectory = { "_Screenshots" };
 #pragma endregion

--- a/System/Constants.h
+++ b/System/Constants.h
@@ -10,7 +10,7 @@ namespace RTE {
 #pragma endregion
 
 #pragma region Game Version
-	static constexpr char *c_GameVersion = "Pre-release 3";
+	static constexpr char *c_GameVersion = "Pre-Release 3";
 #pragma endregion
 
 #pragma region Filesystem Constants


### PR DESCRIPTION
* Add version number to main menu.

* If a metagame is not in progress then pressing "cancel" in the metagame setup screen leads back to the main menu.

* A bunch of changes to make GUI elements have a position that is relative to their appropriate container. Previously they were relative to "root" which had an arbitrary location.

* Credits sequence duration reduced to 90 seconds from 180 seconds.

Dependent on [#61 in data repo](https://github.com/cortex-command-community/Cortex-Command-Community-Project-Data/pull/61).