### PR TITLE
Pressing escape at various main menu screens no longer quits the game.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -256,6 +256,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - The "woosh" sound played when switching actors from a distance will now take scene wrapping into account. Additionally, attempting to switch to previous or next actor with only one actor will play the more correct "error" sound.
 
+- Pressing escape at the options screen no longer quits the game.
+
 ### Removed
 
 - Removed the ability to remove scripts from objects with Lua. This is no longer needed cause of code efficiency increases.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -256,7 +256,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - The "woosh" sound played when switching actors from a distance will now take scene wrapping into account. Additionally, attempting to switch to previous or next actor with only one actor will play the more correct "error" sound.
 
-- Pressing escape at the options screen no longer quits the game.
+- Pressing escape at the options, mod manager, game editors and credits screens no longer quits the game.
 
 ### Removed
 

--- a/Menus/MainMenuGUI.cpp
+++ b/Menus/MainMenuGUI.cpp
@@ -636,37 +636,23 @@ void MainMenuGUI::Update()
 
     // If esc pressed, show quit dialog if applicable
 	if (g_UInputMan.KeyPressed(KEY_ESC)) {
-		if (m_MenuScreen == OPTIONSSCREEN) {
+		if (m_MenuScreen == OPTIONSSCREEN || m_MenuScreen == MODMANAGERSCREEN || m_MenuScreen == EDITORSCREEN || m_MenuScreen == CREDITSSCREEN) {
 			HideAllScreens();
 			m_MainMenuButtons[BACKTOMAIN]->SetVisible(false);
-
-			g_SettingsMan.SetFlashOnBrainDamage(m_aOptionsCheckbox[FLASHONBRAINDAMAGE]->GetCheck());
-			g_SettingsMan.SetBlipOnRevealUnseen(m_aOptionsCheckbox[BLIPONREVEALUNSEEN]->GetCheck());
-			g_SettingsMan.SetShowForeignItems(m_aOptionsCheckbox[SHOWFOREIGNITEMS]->GetCheck());
-			g_SettingsMan.SetShowToolTips(m_aOptionsCheckbox[SHOWTOOLTIPS]->GetCheck());
-			g_SettingsMan.SetPreciseCollisions(m_aOptionsCheckbox[PRECISECOLLISIONS]->GetCheck());
-			g_SettingsMan.UpdateSettingsFile();
-
 			m_MenuScreen = MAINSCREEN;
 			m_ScreenChange = true;
-
 			g_GUISound.BackButtonPressSound()->Play();
-		} else if (m_MenuScreen == MODMANAGERSCREEN) {
-			g_SettingsMan.UpdateSettingsFile();
 
-			HideAllScreens();
-			m_MenuScreen = MAINSCREEN;
-			m_ScreenChange = true;
-
-			g_GUISound.BackButtonPressSound()->Play();
-		} else if (m_MenuScreen == EDITORSCREEN || m_MenuScreen == CREDITSSCREEN) {
-			HideAllScreens();
-			m_MainMenuButtons[BACKTOMAIN]->SetVisible(false);
-
-			m_MenuScreen = MAINSCREEN;
-			m_ScreenChange = true;
-
-			g_GUISound.BackButtonPressSound()->Play();
+			if (m_MenuScreen == OPTIONSSCREEN) {
+				g_SettingsMan.SetFlashOnBrainDamage(m_aOptionsCheckbox[FLASHONBRAINDAMAGE]->GetCheck());
+				g_SettingsMan.SetBlipOnRevealUnseen(m_aOptionsCheckbox[BLIPONREVEALUNSEEN]->GetCheck());
+				g_SettingsMan.SetShowForeignItems(m_aOptionsCheckbox[SHOWFOREIGNITEMS]->GetCheck());
+				g_SettingsMan.SetShowToolTips(m_aOptionsCheckbox[SHOWTOOLTIPS]->GetCheck());
+				g_SettingsMan.SetPreciseCollisions(m_aOptionsCheckbox[PRECISECOLLISIONS]->GetCheck());
+				g_SettingsMan.UpdateSettingsFile();
+			} else if (m_MenuScreen == MODMANAGERSCREEN) {
+				g_SettingsMan.UpdateSettingsFile();
+			}
 		} else {
 			QuitLogic();
 		}

--- a/Menus/MainMenuGUI.cpp
+++ b/Menus/MainMenuGUI.cpp
@@ -636,9 +636,7 @@ void MainMenuGUI::Update()
 
     // If esc pressed, show quit dialog if applicable
 	if (g_UInputMan.KeyPressed(KEY_ESC)) {
-		if (m_MenuScreen != OPTIONSSCREEN) {
-			QuitLogic();
-		} else {
+		if (m_MenuScreen == OPTIONSSCREEN) {
 			HideAllScreens();
 			m_MainMenuButtons[BACKTOMAIN]->SetVisible(false);
 
@@ -653,6 +651,24 @@ void MainMenuGUI::Update()
 			m_ScreenChange = true;
 
 			g_GUISound.BackButtonPressSound()->Play();
+		} else if (m_MenuScreen == MODMANAGERSCREEN) {
+			g_SettingsMan.UpdateSettingsFile();
+
+			HideAllScreens();
+			m_MenuScreen = MAINSCREEN;
+			m_ScreenChange = true;
+
+			g_GUISound.BackButtonPressSound()->Play();
+		} else if (m_MenuScreen == EDITORSCREEN || m_MenuScreen == CREDITSSCREEN) {
+			HideAllScreens();
+			m_MainMenuButtons[BACKTOMAIN]->SetVisible(false);
+
+			m_MenuScreen = MAINSCREEN;
+			m_ScreenChange = true;
+
+			g_GUISound.BackButtonPressSound()->Play();
+		} else {
+			QuitLogic();
 		}
 	}
 

--- a/Menus/MainMenuGUI.cpp
+++ b/Menus/MainMenuGUI.cpp
@@ -635,8 +635,26 @@ void MainMenuGUI::Update()
         return;
 
     // If esc pressed, show quit dialog if applicable
-    if (g_UInputMan.KeyPressed(KEY_ESC))
-        QuitLogic();
+	if (g_UInputMan.KeyPressed(KEY_ESC)) {
+		if (m_MenuScreen != OPTIONSSCREEN) {
+			QuitLogic();
+		} else {
+			HideAllScreens();
+			m_MainMenuButtons[BACKTOMAIN]->SetVisible(false);
+
+			g_SettingsMan.SetFlashOnBrainDamage(m_aOptionsCheckbox[FLASHONBRAINDAMAGE]->GetCheck());
+			g_SettingsMan.SetBlipOnRevealUnseen(m_aOptionsCheckbox[BLIPONREVEALUNSEEN]->GetCheck());
+			g_SettingsMan.SetShowForeignItems(m_aOptionsCheckbox[SHOWFOREIGNITEMS]->GetCheck());
+			g_SettingsMan.SetShowToolTips(m_aOptionsCheckbox[SHOWTOOLTIPS]->GetCheck());
+			g_SettingsMan.SetPreciseCollisions(m_aOptionsCheckbox[PRECISECOLLISIONS]->GetCheck());
+			g_SettingsMan.UpdateSettingsFile();
+
+			m_MenuScreen = MAINSCREEN;
+			m_ScreenChange = true;
+
+			g_GUISound.BackButtonPressSound()->Play();
+		}
+	}
 
     ////////////////////////////////////////////////////////////////////////
     // Animate the menu into and out of view if enabled or disabled


### PR DESCRIPTION
Pressing escape at the options, mod manager, game editors and credits screens no longer quits the game.
Instead, the same actions are performed as if the "back to main" button was pressed.