### PR TITLE
Make AudioMan check for "activity not paused" rather than "activity running"

### DIFF
--- a/Managers/AudioMan.cpp
+++ b/Managers/AudioMan.cpp
@@ -106,7 +106,7 @@ namespace RTE {
 
 			FMOD_RESULT status = FMOD_OK;
 
-			if (g_ActivityMan.ActivityRunning()) {
+			if (!g_ActivityMan.ActivityPaused()) {
 				const Activity *currentActivity = g_ActivityMan.GetActivity();
 				int currentActivityHumanCount = m_IsInMultiplayerMode ? 1 : currentActivity->GetHumanCount();
 


### PR DESCRIPTION
Probably shouldn't mess anything up

Fixes #351 