### PR TITLE
Fix GibWoundLimit conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,6 +183,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- Wound limit gibbing logic has changed for `MOSRotating` (and all its subclasses), where objects will now gib when they reach their `GibWoundLimit` rather than when they surpass it. This allows for one-wound gibbing, which was previously infeasible.
+
 - `TDExplosive`s will no longer default to a looping animation when activated. Instead, they change to the second frame (i.e 001), similarly to `HDFirearm`. Set `SpriteAnimMode` to `4` if you wish to enable the looping active animation.
 
 - `AHuman` can now manually reload BG devices.

--- a/Entities/MOSRotating.cpp
+++ b/Entities/MOSRotating.cpp
@@ -455,7 +455,7 @@ int MOSRotating::GetWoundCount(bool includePositiveDamageAttachables, bool inclu
 
 void MOSRotating::AddWound(AEmitter *woundToAdd, const Vector &parentOffsetToSet, bool checkGibWoundLimit) {
     if (woundToAdd) {
-        if (checkGibWoundLimit && !ToDelete() && m_GibWoundLimit > 0 && m_Wounds.size() + 1 > m_GibWoundLimit) {
+        if (checkGibWoundLimit && !ToDelete() && m_GibWoundLimit > 0 && m_Wounds.size() + 1 >= m_GibWoundLimit) {
             // Indicate blast in opposite direction of emission
             // TODO: don't hardcode here, get some data from the emitter
             Vector blast(-5, 0);


### PR DESCRIPTION
Fix GibWoundLimit conditions so that reaching the limit (rather than exceeding it) actually triggers gibbing, otherwise you couldn't have objects that gib on one wound. Zero has always been equal to no limit.

See data followup.