### PR TITLE
GI#275 - Tech string to module property

### DIFF
--- a/Activities/MultiplayerServerLobby.cpp
+++ b/Activities/MultiplayerServerLobby.cpp
@@ -303,31 +303,16 @@ namespace RTE {
 		m_pCPULockLabel = dynamic_cast<GUILabel *>(m_pGUIController->GetControl("CPULockLabel"));
 
 		// Populate the tech comboboxes with the available tech modules
-		const DataModule *pModule = 0;
-		string techName;
-		string techString = " Tech";
-		string::size_type techPos = string::npos;
-		for (int i = 0; i < g_PresetMan.GetTotalModuleCount(); ++i)
-		{
-			pModule = g_PresetMan.GetDataModule(i);
-			if (pModule)
-			{
-				techName = pModule->GetFriendlyName();
-				if ((techPos = techName.find(techString)) != string::npos)
-				{
-					techName.replace(techPos, techString.length(), "");
-					m_apTeamTechSelect[Teams::TeamOne]->GetListPanel()->AddItem(techName, "", 0, 0, i);
-					m_apTeamTechSelect[Teams::TeamTwo]->GetListPanel()->AddItem(techName, "", 0, 0, i);
-					m_apTeamTechSelect[Teams::TeamThree]->GetListPanel()->AddItem(techName, "", 0, 0, i);
-					m_apTeamTechSelect[Teams::TeamFour]->GetListPanel()->AddItem(techName, "", 0, 0, i);
+		for (int moduleID = 0; moduleID < g_PresetMan.GetTotalModuleCount(); ++moduleID) {
+			if (const DataModule *dataModule = g_PresetMan.GetDataModule(moduleID)) {
+				if (dataModule->IsFaction()) {
+					for (int team = Activity::Teams::TeamOne; team < Activity::Teams::MaxTeamCount; ++team) {
+						m_apTeamTechSelect[team]->GetListPanel()->AddItem(dataModule->GetFriendlyName(), "", nullptr, nullptr, moduleID);
+						m_apTeamTechSelect[team]->GetListPanel()->ScrollToTop();
+					}
 				}
 			}
 		}
-		// Make the lists be scrolled to the top when they are initially dropped
-		m_apTeamTechSelect[Teams::TeamOne]->GetListPanel()->ScrollToTop();
-		m_apTeamTechSelect[Teams::TeamTwo]->GetListPanel()->ScrollToTop();
-		m_apTeamTechSelect[Teams::TeamThree]->GetListPanel()->ScrollToTop();
-		m_apTeamTechSelect[Teams::TeamFour]->GetListPanel()->ScrollToTop();
 
 		m_pGoldLabel = dynamic_cast<GUILabel *>(m_pGUIController->GetControl("GoldLabel"));
 		m_pGoldSlider = dynamic_cast<GUISlider *>(m_pGUIController->GetControl("GoldSlider"));

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,6 +185,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - New `Settings.ini` property `ShowEnemyHUD` which allows disabling of enemy actor HUD in its entirety.
 
+- New `DataModule` property `IsFaction = 0/1` which determines if a module is a playable faction (in MetaGame, etc.). This replaces the need to put "Tech" in the module name. Defaults to false (0).
+
 ### Changed
 
 - Doors in `Team = -1` will now open up for all actors.
@@ -308,6 +310,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Settings menu was reworked to make it less useless.
 
 - Esc has been disabled in server mode to not disrupt simulation for clients, use Alt+F4 or the window close button to exit.
+
+- Placing "Tech" in a `DataModule`'s `ModuleName` no longer makes the module a playable faction (in MetaGame, etc.). The `IsFaction` property should be used instead.  
+	The word "Tech" will also not be omitted from the module name when displayed in any faction selection dropdown list.
 
 ### Fixed
 

--- a/Entities/Deployment.cpp
+++ b/Entities/Deployment.cpp
@@ -240,22 +240,14 @@ Actor * Deployment::CreateDeployedActor(int player, float &costTally)
 			//m_Team = activity->GetTeamOfPlayer(player);
 			nativeModule = g_PresetMan.GetModuleID(activity->GetTeamTech(m_Team));
 			// Select some random module if player selected all or something else
-			if (nativeModule < 0)
-			{
-			    const DataModule *pModule = 0;
-				vector<string> moduleList;
-				string techName;
-				string techString = " Tech";
-				string::size_type techPos = string::npos;
-				
-				for (int i = 0; i < g_PresetMan.GetTotalModuleCount(); ++i)  
-				{
-					pModule = g_PresetMan.GetDataModule(i);
-					techName = pModule->GetFriendlyName();
-					if (pModule && (techPos = techName.find(techString)) != string::npos)
-						moduleList.push_back(pModule->GetFileName());
-				}
+			if (nativeModule < 0) {
+				std::vector<std::string> moduleList;
 
+				for (int moduleID = 0; moduleID < g_PresetMan.GetTotalModuleCount(); ++moduleID) {
+					if (const DataModule *dataModule = g_PresetMan.GetDataModule(moduleID)) {
+						if (dataModule->IsFaction()) { moduleList.emplace_back(dataModule->GetFileName()); }
+					}
+				}
 				int selection = RandomNum<int>(1, moduleList.size() - 1);
 				nativeModule = g_PresetMan.GetModuleID(moduleList.at(selection));
 			}
@@ -331,25 +323,14 @@ SceneObject * Deployment::CreateDeployedObject(int player, float &costTally)
 			//m_Team = activity->GetTeamOfPlayer(player);
 			nativeModule = g_PresetMan.GetModuleID(activity->GetTeamTech(m_Team));
 			// Select some random module if player selected all or something else
-			if (nativeModule < 0)
-			{
-			    const DataModule *pModule = 0;
-				vector<string> moduleList;
-				string techName;
-				string techString = " Tech";
-				string::size_type techPos = string::npos;
-				
-				for (int i = 0; i < g_PresetMan.GetTotalModuleCount(); ++i)  
-				{
-					pModule = g_PresetMan.GetDataModule(i);
-					if (pModule)
-					{
-						techName = pModule->GetFriendlyName();
-						if (techPos = techName.find(techString) != string::npos)
-							moduleList.push_back(pModule->GetFileName());
+			if (nativeModule < 0) {
+				std::vector<std::string> moduleList;
+
+				for (int moduleID = 0; moduleID < g_PresetMan.GetTotalModuleCount(); ++moduleID) {
+					if (const DataModule *dataModule = g_PresetMan.GetDataModule(moduleID)) {
+						if (dataModule->IsFaction()) { moduleList.emplace_back(dataModule->GetFileName()); }
 					}
 				}
-
 				int selection = RandomNum<int>(1, moduleList.size() - 1);
 				nativeModule = g_PresetMan.GetModuleID(moduleList.at(selection));
 			}

--- a/Managers/PresetMan.cpp
+++ b/Managers/PresetMan.cpp
@@ -633,30 +633,15 @@ Entity * PresetMan::GetRandomBuyableOfGroupFromTech(string group, string type, i
     list<Entity *> entityList;
     list<Entity *> tempList;
 
-
-    string techString = " Tech";
-    string techName;
-    string::size_type techPos = string::npos;
-
-    // All modules
-    if (whichModule < 0)
-    {
-        // Get from all modules
-        for (int i = 0; i < m_pDataModules.size(); ++i)
-		{
-			// Select from tech-only modules
-			techName = m_pDataModules[i]->GetFriendlyName();
-			if (techName.find(techString) != string::npos)
-				// Send the list to each module, let them add
-				foundAny = m_pDataModules[i]->GetAllOfGroup(tempList, group, type) || foundAny;
+	// All modules
+	if (whichModule < 0) {
+		for (DataModule *dataModule : m_pDataModules) {
+			if (dataModule->IsFaction()) { foundAny = dataModule->GetAllOfGroup(tempList, group, type) || foundAny; }
 		}
-    }
-    // Specific one
-    else
-    {
-        RTEAssert(whichModule < m_pDataModules.size(), "Trying to get from an out of bounds DataModule ID!");
-        foundAny = m_pDataModules[whichModule]->GetAllOfGroup(tempList, group, type);
-    }
+	} else {
+		RTEAssert(whichModule < m_pDataModules.size(), "Trying to get from an out of bounds DataModule ID!");
+		foundAny = m_pDataModules[whichModule]->GetAllOfGroup(tempList, group, type);
+	}
 
 	//Filter found entities, we need only buyables
 	if (foundAny)

--- a/Menus/MetagameGUI.cpp
+++ b/Menus/MetagameGUI.cpp
@@ -830,15 +830,11 @@ void MetagameGUI::SetEnabled(bool enable)
 		m_apPlayerTechSelect[team]->GetListPanel()->AddItem("-Random-", "", nullptr, nullptr, -1);
 		m_apPlayerTechSelect[team]->SetSelectedIndex(0);
 	}
-	std::string techString = " Tech";
 	for (int moduleID = 0; moduleID < g_PresetMan.GetTotalModuleCount(); ++moduleID) {
 		if (const DataModule *dataModule = g_PresetMan.GetDataModule(moduleID)) {
-			std::string techName = dataModule->GetFriendlyName();
-			size_t techPos = techName.find(techString);
-			if (techPos != string::npos) {
-				techName.replace(techPos, techString.length(), "");
+			if (dataModule->IsFaction()) {
 				for (int team = Activity::Teams::TeamOne; team < Activity::Teams::MaxTeamCount; ++team) {
-					m_apPlayerTechSelect[team]->GetListPanel()->AddItem(techName, "", nullptr, nullptr, moduleID);
+					m_apPlayerTechSelect[team]->GetListPanel()->AddItem(dataModule->GetFriendlyName(), "", nullptr, nullptr, moduleID);
 					m_apPlayerTechSelect[team]->GetListPanel()->ScrollToTop();
 				}
 			}

--- a/Menus/ScenarioActivityConfigGUI.cpp
+++ b/Menus/ScenarioActivityConfigGUI.cpp
@@ -74,15 +74,12 @@ namespace RTE {
 			m_TeamTechComboBoxes.at(team)->GetListPanel()->AddItem("-All-", "", nullptr, nullptr, -2);
 			m_TeamTechComboBoxes.at(team)->GetListPanel()->AddItem("-Random-", "", nullptr, nullptr, -1);
 		}
-		std::string techString = " Tech";
 		for (int moduleID = 0; moduleID < g_PresetMan.GetTotalModuleCount(); ++moduleID) {
 			if (const DataModule *dataModule = g_PresetMan.GetDataModule(moduleID)) {
-				std::string techName = dataModule->GetFriendlyName();
-				size_t techPos = techName.find(techString);
-				if (techPos != string::npos) {
-					techName.replace(techPos, techString.length(), "");
+				if (dataModule->IsFaction()) {
 					for (int team = Activity::Teams::TeamOne; team < Activity::Teams::MaxTeamCount; ++team) {
-						m_TeamTechComboBoxes.at(team)->GetListPanel()->AddItem(techName, "", nullptr, nullptr, moduleID);
+						m_TeamTechComboBoxes.at(team)->GetListPanel()->AddItem(dataModule->GetFriendlyName(), "", nullptr, nullptr, moduleID);
+						m_TeamTechComboBoxes.at(team)->GetListPanel()->ScrollToTop();
 					}
 				}
 			}

--- a/System/DataModule.cpp
+++ b/System/DataModule.cpp
@@ -26,6 +26,7 @@ namespace RTE {
 		m_IgnoreMissingItems = false;
 		m_CrabToHumanSpawnRatio = 0;
 		m_ScriptPath.clear();
+		m_IsFaction = false;
 	}
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -96,6 +97,8 @@ namespace RTE {
 			reader >> m_Author;
 		} else if (propName == "Description") {
 			reader >> m_Description;
+		} else if (propName == "IsFaction") {
+			reader >> m_IsFaction;
 		} else if (propName == "Version") {
 			reader >> m_Version;
 		} else if (propName == "ScanFolderContents") {
@@ -134,6 +137,7 @@ namespace RTE {
 		writer.NewPropertyWithValue("ModuleName", m_FriendlyName);
 		writer.NewPropertyWithValue("Author", m_Author);
 		writer.NewPropertyWithValue("Description", m_Description);
+		writer.NewPropertyWithValue("IsFaction", m_IsFaction);
 		writer.NewPropertyWithValue("Version", m_Version);
 		writer.NewPropertyWithValue("IconFile", m_IconFile);
 

--- a/System/DataModule.h
+++ b/System/DataModule.h
@@ -105,6 +105,12 @@ namespace RTE {
 		const std::string & GetDescription() const { return m_Description; }
 
 		/// <summary>
+		/// Gets whether this DataModule is considered a faction.
+		/// </summary>
+		/// <returns>Whether this DataModule is considered a faction or not.</returns>
+		bool IsFaction() const { return m_IsFaction; }
+
+		/// <summary>
 		/// Gets the version number of this DataModule.
 		/// </summary>
 		/// <returns>An int with the version number, starting at 1.</returns>
@@ -258,6 +264,7 @@ namespace RTE {
 		std::string m_Author; //!< Name of the author of this module.
 		std::string m_Description; //!< Brief description of what this module is and contains.
 		std::string m_ScriptPath; //!< Path to script to execute when this module is loaded.
+		bool m_IsFaction; //!< Whether this data module is considered a faction.
 		int m_Version; //!< Version number, starting with 1.
 		int m_ModuleID; //!< ID number assigned to this upon loading, for internal use only, don't reflect in ini's.
 


### PR DESCRIPTION
- New `DataModule` property `IsFaction = 0/1` which determines if a module is a playable faction (in MetaGame, etc.). This replaces the need to put "Tech" in the module name. Defaults to false (0).
- Placing "Tech" in a `DataModule`'s `ModuleName` no longer makes the module a playable faction (in MetaGame, etc.). The `IsFaction` property should be used instead.  
	The word "Tech" will also not be omitted from the module name when displayed in any faction selection dropdown list.

Resolve #275.