### PR TITLE
[FEAT] Remove 2 out of 3 MOID Layer Draws

### DIFF
--- a/Entities/MovableObject.cpp
+++ b/Entities/MovableObject.cpp
@@ -896,8 +896,8 @@ void MovableObject::ApplyImpulses()
 
 void MovableObject::PreTravel()
 {
-	// Temporarily remove the representation of this from the scene MO layers
-	if (m_GetsHitByMOs) { Draw(g_SceneMan.GetMOIDBitmap(), Vector(), g_DrawNoMOID, true); }
+	// Temporarily remove the representation of this from the scene MO sampler
+	if (m_GetsHitByMOs) { m_tempDisableGettingHit = true; }
 
     // Save previous position and velocities before moving
     m_PrevPos = m_Pos;
@@ -933,7 +933,7 @@ void MovableObject::PostTravel()
         m_IgnoresAtomGroupHits = m_Vel.GetLargest() < m_IgnoresAGHitsWhenSlowerThan;
 
 	if (m_GetsHitByMOs) {
-        if (!GetParent()) { Draw(g_SceneMan.GetMOIDBitmap(), Vector(), g_DrawMOID, true); }
+        if (!GetParent()) { m_tempDisableGettingHit = false; }
 		m_AlreadyHitBy.clear();
 	}
 	m_IsUpdated = true;

--- a/Entities/MovableObject.h
+++ b/Entities/MovableObject.h
@@ -1806,6 +1806,8 @@ enum MOType
 
 	void SetProvidesPieMenuContext(bool value) { m_ProvidesPieMenuContext = value; }
 
+// Set to true while travelling; prevents self-intersection
+bool m_tempDisableGettingHit;
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // Protected member variable and method declarations

--- a/Managers/SceneMan.cpp
+++ b/Managers/SceneMan.cpp
@@ -612,7 +612,13 @@ MOID SceneMan::GetMOIDPixel(int pixelX, int pixelY)
        pixelY >= m_pMOIDLayer->GetBitmap()->h)
         return g_NoMOID;
 
-    return getpixel(m_pMOIDLayer->GetBitmap(), pixelX, pixelY);
+    MOID moid = getpixel(m_pMOIDLayer->GetBitmap(), pixelX, pixelY);
+    if (moid != g_NoMOID && moid != g_MOIDMaskColor) {
+        MOSprite* mo = dynamic_cast<MOSprite*>(g_MovableMan.GetMOFromID(moid));
+        return (mo && !mo->GetRootParent()->m_tempDisableGettingHit) ? moid : g_NoMOID;
+    } else {
+        return g_NoMOID;
+    }
 }
 
 


### PR DESCRIPTION
Replace the need for MOIDs to undraw and redraw themselves during travelling with a simple flag to check whether they're currently traveling.

Since this makes GetMOIDPixel a bit heavier, it's dubious as to whether this is faster or not...   (and, though I haven't thoroughly tested this for bugs, it seems good).