### PR TITLE
Fix decimal point localization

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -46,8 +46,8 @@ jobs:
         # uses: BSFishy/meson-build@6f1930d878fd3eed3853c1c91285ec604c37f3a5
         uses: BSFishy/meson-build@v1.0.3
         env:
-          CC: "ccache clang"
-          CXX: "ccache clang++"
+          CC: "clang"
+          CXX: "clang++"
           CCACHE_SLOPPINESS: pch_defines,time_macros,include_file_mtime,include_file_ctime
         with:
           # The action to run

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -46,8 +46,8 @@ jobs:
         # uses: BSFishy/meson-build@6f1930d878fd3eed3853c1c91285ec604c37f3a5
         uses: BSFishy/meson-build@v1.0.3
         env:
-          CC: "ccache clang"
-          CXX: "ccache clang++"
+          CC: "clang"
+          CXX: "clang++"
           CCACHE_SLOPPINESS: pch_defines,time_macros,include_file_mtime,include_file_ctime
         with:
           # The action to run

--- a/Entities/Attachable.cpp
+++ b/Entities/Attachable.cpp
@@ -125,7 +125,10 @@ namespace RTE {
 		} else if (propName == "InheritedRotAngleRadOffset" || propName == "InheritedRotAngleOffset") {
 			reader >> m_InheritedRotAngleOffset;
 		} else if (propName == "InheritedRotAngleDegOffset") {
+			const char* locale = std::setlocale(LC_ALL, nullptr);
+			std::setlocale(LC_ALL, "C");
 			m_InheritedRotAngleOffset = DegreesToRadians(std::stof(reader.ReadPropValue()));
+			std::setlocale(LC_ALL, locale);
 		} else if (propName == "InheritsFrame") {
 			reader >> m_InheritsFrame;
 		} else if (propName == "CollidesWithTerrainWhileAttached") {

--- a/Entities/MOSRotating.cpp
+++ b/Entities/MOSRotating.cpp
@@ -354,11 +354,14 @@ void MOSRotating::ReadCustomValueProperty(Reader &reader) {
     std::string customKey = reader.ReadPropName();
     std::string customValue = reader.ReadPropValue();
     if (customValueType == "NumberValue") {
+		const char* lcale = std::setlocale(LC_ALL, nullptr);
+		std::setlocale(LC_ALL, "C");
         try {
             SetNumberValue(customKey, std::stod(customValue));
         } catch (const std::invalid_argument) {
             reader.ReportError("Tried to read a non-number value for SetNumberValue.");
         }
+		std::setlocale(LC_ALL, lcale);
     } else if (customValueType == "StringValue") {
         SetStringValue(customKey, customValue);
     } else {

--- a/Entities/SoundContainer.cpp
+++ b/Entities/SoundContainer.cpp
@@ -187,6 +187,8 @@ namespace RTE {
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 	FMOD_RESULT SoundContainer::UpdateSoundProperties() {
+		if (!m_Immobile) { m_Volume = 0.0F; }
+
 		FMOD_RESULT result = FMOD_OK;
 
 		std::vector<SoundSet::SoundData *> flattenedSoundData;

--- a/Managers/SettingsMan.cpp
+++ b/Managers/SettingsMan.cpp
@@ -90,6 +90,8 @@ namespace RTE {
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 	int SettingsMan::ReadProperty(const std::string_view &propName, Reader &reader) {
+		const char* locale = std::setlocale(LC_ALL, nullptr);
+		std::setlocale(LC_ALL, "C");
 		if (propName == "PaletteFile") {
 			reader >> g_FrameMan.m_PaletteFile;
 		} else if (propName == "ResolutionX") {
@@ -265,8 +267,10 @@ namespace RTE {
 				}
 			}
 		} else {
+			std::setlocale(LC_ALL, locale);
 			return Serializable::ReadProperty(propName, reader);
 		}
+		std::setlocale(LC_ALL, locale);
 		return 0;
 	}
 

--- a/System/Matrix.cpp
+++ b/System/Matrix.cpp
@@ -61,7 +61,10 @@ namespace RTE {
 
 	int Matrix::ReadProperty(const std::string_view &propName, Reader &reader) {
 		if (propName == "AngleDegrees") {
+			const char* locale = std::setlocale(LC_ALL, nullptr);
+			std::setlocale(LC_ALL, "C");
 			SetDegAngle(std::stof(reader.ReadPropValue()));
+			std::setlocale(LC_ALL, locale);
 		} else if (propName == "AngleRadians") {
 			reader >> m_Rotation;
 		} else {


### PR DESCRIPTION
forces decimal separator to be `0.0f` ignoring system locale (probably applies only to linux) so systems where the decimal separator isn't `0.0f` won't miss the fractional part when reading numbers.

Fixes:
- Recoil on banshee
- Any other misreading of floating point number attributes