### PR TITLE
Fix for unsorted filesystems

### DIFF
--- a/Managers/PresetMan.cpp
+++ b/Managers/PresetMan.cpp
@@ -181,7 +181,7 @@ bool PresetMan::LoadAllDataModules() {
 		std::vector<std::filesystem::directory_entry> workingDirectoryFolders;
 		std::copy_if(std::filesystem::directory_iterator(System::GetWorkingDirectory()), std::filesystem::directory_iterator(), std::back_inserter(workingDirectoryFolders),
 			[](auto dirEntry){ return std::filesystem::is_directory(dirEntry); }
-        );
+		);
 		std::sort(workingDirectoryFolders.begin(), workingDirectoryFolders.end());
 
 		for (const std::filesystem::directory_entry &directoryEntry : workingDirectoryFolders) {

--- a/Managers/PresetMan.cpp
+++ b/Managers/PresetMan.cpp
@@ -180,10 +180,10 @@ bool PresetMan::LoadAllDataModules() {
 	} else {
 		std::vector<std::filesystem::directory_entry> workingDirectoryFolders;
 		std::copy_if(std::filesystem::directory_iterator(System::GetWorkingDirectory()), std::filesystem::directory_iterator(), std::back_inserter(workingDirectoryFolders),
-					 [](auto dirEntry){
-						 return std::filesystem::is_directory(dirEntry);
-					 });
+			[](auto dirEntry){ return std::filesystem::is_directory(dirEntry); }
+        );
 		std::sort(workingDirectoryFolders.begin(), workingDirectoryFolders.end());
+
 		for (const std::filesystem::directory_entry &directoryEntry : workingDirectoryFolders) {
 			std::string directoryEntryPath = directoryEntry.path().generic_string();
 			if (std::regex_match(directoryEntryPath, std::regex(".*\.rte"))) {

--- a/Managers/PresetMan.cpp
+++ b/Managers/PresetMan.cpp
@@ -178,9 +178,15 @@ bool PresetMan::LoadAllDataModules() {
 			return false;
 		}
 	} else {
-		for (const std::filesystem::directory_entry &directoryEntry : std::filesystem::directory_iterator(System::GetWorkingDirectory())) {
+		std::vector<std::filesystem::directory_entry> workingDirectoryFolders;
+		std::copy_if(std::filesystem::directory_iterator(System::GetWorkingDirectory()), std::filesystem::directory_iterator(), std::back_inserter(workingDirectoryFolders),
+					 [](auto dirEntry){
+						 return std::filesystem::is_directory(dirEntry);
+					 });
+		std::sort(workingDirectoryFolders.begin(), workingDirectoryFolders.end());
+		for (const std::filesystem::directory_entry &directoryEntry : workingDirectoryFolders) {
 			std::string directoryEntryPath = directoryEntry.path().generic_string();
-			if (std::filesystem::is_directory(directoryEntryPath) && std::regex_match(directoryEntryPath, std::regex(".*\.rte"))) {
+			if (std::regex_match(directoryEntryPath, std::regex(".*\.rte"))) {
 				std::string moduleName = directoryEntryPath.substr(directoryEntryPath.find_last_of('/') + 1, std::string::npos);
 				if (!g_SettingsMan.IsModDisabled(moduleName) && (std::find(officialModules.begin(), officialModules.end(), moduleName) == officialModules.end() && moduleName != "Metagames.rte" && moduleName != "Scenes.rte")) {
 					int moduleID = GetModuleID(moduleName);


### PR DESCRIPTION
Fixes random loading bugs that appear on linux due to the filesystem not being ordered by pre-sorting the directory list. (This is only an issue when loading (non base) datamodules, since that assumes modules are loaded in alphabetical order, all other directory iterators work without that assumption)

I'm surprised this hasn't been an issue for windows, though then again ntfs' b-tree is at least close to (english) alphabetical ordering