### PR TITLE
Added assertion for a defined AtomGroup in `MOSRotating::Travel()`.

### DIFF
--- a/Entities/MOSRotating.cpp
+++ b/Entities/MOSRotating.cpp
@@ -1412,6 +1412,8 @@ void MOSRotating::Travel()
     // Reset the travel impulse for this frame
     m_TravelImpulse.Reset();
 
+	RTEAssert(m_pAtomGroup, "No AtomGroup defined for MOSRotating " + GetPresetName() + " in Travel!");
+
     // Set the atom to ignore a certain MO, if set and applicable.
     if (m_HitsMOs && m_pMOToNotHit && g_MovableMan.ValidMO(m_pMOToNotHit) && !m_MOIgnoreTimer.IsPastSimTimeLimit()) {
         std::vector<MOID> MOIDsNotToHit;


### PR DESCRIPTION
Closes #393, cos I ain't a good modder and I don't think I'll be the first one to be confused by it.