### PR TITLE
[Linux] Fix mouse input drops

### DIFF
--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -123,7 +123,7 @@ jobs:
           CCACHE_SLOPPINESS: pch_defines,time_macros,include_file_mtime,include_file_ctime
         with:
           # The action to run
-          setup-options: --buildtype=debug -Dinstall_data=false -Dinstall_runner=false -Dfmod_dir=/usr/lib/ --prefix=/usr/ -Ddebug_type=release --optimization=2
+          setup-options: --buildtype=debugoptimized -Dinstall_data=false -Dinstall_runner=false -Dfmod_dir=/usr/lib/ --prefix=/usr/ -Ddebug_type=release
           meson-version: 0.55.3
           ninja-version: 1.10.0
           action: build

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -81,3 +81,75 @@ jobs:
         with:
           name: CortexCommand.AppImage
           path: CortexCommand.AppImage
+
+
+  build-debug-linux:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-20.04
+
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update -yq
+          sudo apt-get install --no-install-recommends wget liballegro4-dev libloadpng4-dev libflac++-dev luajit-5.1-dev libminizip-dev liblz4-dev libpng++-dev libx11-dev libboost-dev
+
+      - name: Install Clang
+        # You may pin to the exact commit or the version.
+        # uses: egor-tensin/setup-clang@d16e36d5f8a7eb00aa6627c1a536d94dfc4a913d
+        uses: egor-tensin/setup-clang@v1
+        with:
+          # Set up cc/c++ executables
+          cc: 1 # optional, default is 1
+
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: build-release-${{runner.os}}
+          max-size: 5G
+
+      - name: Build
+        # You may pin to the exact commit or the version.
+        # uses: BSFishy/meson-build@6f1930d878fd3eed3853c1c91285ec604c37f3a5
+        uses: BSFishy/meson-build@v1.0.3
+        env:
+          CC: "clang"
+          CXX: "clang++"
+          CCACHE_SLOPPINESS: pch_defines,time_macros,include_file_mtime,include_file_ctime
+        with:
+          # The action to run
+          setup-options: --buildtype=debug -Dinstall_data=false -Dinstall_runner=false -Dfmod_dir=/usr/lib/ --prefix=/usr/ -Ddebug_type='release' --optimization=2
+          meson-version: 0.55.3
+          ninja-version: 1.10.0
+          action: build
+
+      - name: Create AppDir
+        run: |
+          echo "Setting output prefix"
+          DESTDIR=${GITHUB_WORKSPACE}/build/AppDir meson install -C $GITHUB_WORKSPACE"/build"
+
+      - name: Download linuxdeploy
+        working-directory: ${{env.GITHUB_WORKSPACE}}
+        run: |
+          wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage -O lindeploy
+          chmod +x lindeploy
+
+      - name: Create AppImage
+        working-directory: ${{env.GITHUB_WORKSPACE}}
+        env:
+          LD_LIBRARY_PATH: ./external/lib/linux/x86_64/
+          OUTPUT: CortexCommand-debug.AppImage
+        run: |
+          echo ${LD_LIBRARY_PATH}
+          ./lindeploy --appdir=build/AppDir --output appimage
+
+      - name: Upload Appimage
+        uses: actions/upload-artifact@v2
+        with:
+          name: CortexCommand-debug.AppImage
+          path: CortexCommand-debug.AppImage

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -123,7 +123,7 @@ jobs:
           CCACHE_SLOPPINESS: pch_defines,time_macros,include_file_mtime,include_file_ctime
         with:
           # The action to run
-          setup-options: --buildtype=debug -Dinstall_data=false -Dinstall_runner=false -Dfmod_dir=/usr/lib/ --prefix=/usr/ -Ddebug_type='release' --optimization=2
+          setup-options: --buildtype=debug -Dinstall_data=false -Dinstall_runner=false -Dfmod_dir=/usr/lib/ --prefix=/usr/ -Ddebug_type=release --optimization=2
           meson-version: 0.55.3
           ninja-version: 1.10.0
           action: build

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -123,7 +123,7 @@ jobs:
           CCACHE_SLOPPINESS: pch_defines,time_macros,include_file_mtime,include_file_ctime
         with:
           # The action to run
-          setup-options: --buildtype=debugoptimized -Dinstall_data=false -Dinstall_runner=false -Dfmod_dir=/usr/lib/ --prefix=/usr/ -Ddebug_type=release
+          setup-options: -Ddebug=true --optimization=g -Dinstall_data=false -Dinstall_runner=false -Dfmod_dir=/usr/lib/ --prefix=/usr/ -Ddebug_type=release
           meson-version: 0.55.3
           ninja-version: 1.10.0
           action: build

--- a/Managers/UInputMan.cpp
+++ b/Managers/UInputMan.cpp
@@ -1002,11 +1002,12 @@ namespace RTE {
 			XNextEvent(_xwin.display, &e);
 			events.push_back(e);
 		}
+
 		static int mousePrevX = 0;
 		static int mousePrevY = 0;
 		int dx = 0;
 		int dy = 0;
-		int n = 0;
+
 		for (auto event = events.rbegin(); event < events.rend(); ++event) {
 			switch (event->type) {
 				case MotionNotify: {
@@ -1020,7 +1021,6 @@ namespace RTE {
 					if (g_UInputMan.m_TrapMousePos) {
 						XWarpPointer(_xwin.display, _xwin.window, _xwin.window, 0, 0, 0, 0, _xwin.window_width / 2, _xwin.window_height / 2);
 					}
-					++n;
 				} break;
 
 				default:
@@ -1028,9 +1028,12 @@ namespace RTE {
 					break;
 			}
 		}
+
 		XFlush(_xwin.display);
+
 		_xwin.mouse_warped = 0;
 		_xwin_private_handle_input();
+
 		_mouse_x = mouse_x;
 		_mouse_y = mouse_y;
 	}

--- a/Managers/UInputMan.cpp
+++ b/Managers/UInputMan.cpp
@@ -126,7 +126,7 @@ namespace RTE {
 		poll_joystick();
 
 #ifdef __unix__
-		_xwin_input_handler = HandleAllegroMouseInput;
+		_xwin_input_handler = XWinInputHandlerOverride;
 #endif
 
 		return 0;
@@ -1034,8 +1034,8 @@ namespace RTE {
 			events.push_back(e);
 		}
 
-		g_UInputMan.m_AllegroMousePreviousX = mouse_x;
-		g_UInputMan.m_AllegroMousePreviousY = mouse_y;
+		m_AllegroMousePreviousX = mouse_x;
+		m_AllegroMousePreviousY = mouse_y;
 		int mouseDeltaX = 0;
 		int mouseDeltaY = 0;
 
@@ -1044,13 +1044,13 @@ namespace RTE {
 		for (std::vector<XEvent>::reverse_iterator event = events.rbegin(); event < events.rend(); ++event) {
 			switch (event->type) {
 				case MotionNotify: {
-					mouseDeltaX = event->xmotion.x - g_UInputMan.m_AllegroMousePreviousX;
-					mouseDeltaY = event->xmotion.y - g_UInputMan.m_AllegroMousePreviousY;
+					mouseDeltaX = event->xmotion.x - m_AllegroMousePreviousX;
+					mouseDeltaY = event->xmotion.y - m_AllegroMousePreviousY;
 					_xwin_mouse_interrupt(mouseDeltaX, mouseDeltaY, 0, 0, mouse_b);
-					_mouse_x = g_UInputMan.m_AllegroMousePreviousX = !g_UInputMan.m_TrapMousePos ? event->xmotion.x : halfResX;
-					_mouse_y = g_UInputMan.m_AllegroMousePreviousY = !g_UInputMan.m_TrapMousePos ? event->xmotion.y : halfResY;
+					_mouse_x = m_AllegroMousePreviousX = !m_TrapMousePos ? event->xmotion.x : halfResX;
+					_mouse_y = m_AllegroMousePreviousY = !m_TrapMousePos ? event->xmotion.y : halfResY;
 
-					if (g_UInputMan.m_TrapMousePos && (mouseDeltaX != 0 || mouseDeltaY != 0)) {
+					if (m_TrapMousePos && (mouseDeltaX != 0 || mouseDeltaY != 0)) {
 						XWarpPointer(_xwin.display, _xwin.window, _xwin.window, 0, 0, 0, 0, halfResX, halfResY);
 					}
 					break;
@@ -1067,7 +1067,7 @@ namespace RTE {
 		_xwin.mouse_warped = 0;
 		_xwin_private_handle_input();
 
-		if (g_UInputMan.m_TrapMousePos) {
+		if (m_TrapMousePos) {
 			mouse_x = _xwin.window_width / 2;
 			mouse_y = _xwin.window_height / 2;
 		}

--- a/Managers/UInputMan.cpp
+++ b/Managers/UInputMan.cpp
@@ -720,7 +720,6 @@ namespace RTE {
 		int mickeyX;
 		int mickeyY;
 		get_mouse_mickeys(&mickeyX, &mickeyY);
-
 		m_RawMouseMovement.SetXY(mickeyX, mickeyY);
 
 		// TODO: Add sensitivity slider to settings menu
@@ -876,10 +875,8 @@ namespace RTE {
 			if (!m_DisableMouseMoving && !IsInMultiplayerMode()) {
 				if (m_TrapMousePos) {
 					// Trap the (invisible) mouse cursor in the middle of the screen, so it doesn't fly out in windowed mode and some other window gets clicked
-#ifdef __unix__
-					// Note - For the linux version the centering is partially done in the event loop, this just resets the allegro mouse position
-					position_mouse(_xwin.window_width / 2, _xwin.window_height / 2);
-#else
+					// Note - on linux the centering is done in the event loop.
+#ifndef __unix__
 					position_mouse(g_FrameMan.GetResX() / 2, g_FrameMan.GetResY() / 2);
 #endif
 				} else if (g_ActivityMan.IsInActivity()) {
@@ -1029,7 +1026,6 @@ namespace RTE {
 					if (g_UInputMan.m_TrapMousePos) {
 						XWarpPointer(_xwin.display, _xwin.window, _xwin.window, 0, 0, 0, 0, _xwin.window_width / 2, _xwin.window_height / 2);
 					}
-
 				} break;
 
 				default:
@@ -1043,8 +1039,14 @@ namespace RTE {
 		_xwin.mouse_warped = 0;
 		_xwin_private_handle_input();
 
+		if(g_UInputMan.m_TrapMousePos){
+			mouse_x = _xwin.window_width / 2;
+			mouse_y = _xwin.window_height / 2;
+		}
+
 		_mouse_x = mouse_x;
 		_mouse_y = mouse_y;
+
 	}
 #endif
 }

--- a/Managers/UInputMan.cpp
+++ b/Managers/UInputMan.cpp
@@ -1059,6 +1059,8 @@ namespace RTE {
 		_mouse_y = mouse_y;
 	}
 
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 	void UInputMan::WarpMouse(int x, int y) const {
 		if (mouse_x != x || mouse_y != y) {
 			XWarpPointer(_xwin.display, _xwin.window, _xwin.window, 0, 0, 0, 0, x, y);

--- a/Managers/UInputMan.cpp
+++ b/Managers/UInputMan.cpp
@@ -421,6 +421,7 @@ namespace RTE {
 #ifdef __unix__
 			if (m_TrapMousePos != prevTrapStatus) {
 				WarpMouse(_xwin.window_width / 2, _xwin.window_height / 2);
+				// Note - Discard mickeys after this warp otherwise mouse will probably jump.
 				int discard;
 				get_mouse_mickeys(&discard, &discard);
 				WarpMouse(_xwin.window_width / 2, _xwin.window_height / 2);

--- a/Managers/UInputMan.cpp
+++ b/Managers/UInputMan.cpp
@@ -423,8 +423,6 @@ namespace RTE {
 				WarpMouse(_xwin.window_width / 2, _xwin.window_height / 2);
 				int discard;
 				get_mouse_mickeys(&discard, &discard);
-				get_mouse_mickeys(&discard, &discard);
-				get_mouse_mickeys(&discard, &discard);
 				WarpMouse(_xwin.window_width / 2, _xwin.window_height / 2);
 			}
 #endif

--- a/Managers/UInputMan.cpp
+++ b/Managers/UInputMan.cpp
@@ -889,7 +889,12 @@ namespace RTE {
 			if (!m_DisableMouseMoving && !IsInMultiplayerMode()) {
 				if (m_TrapMousePos) {
 					// Trap the (invisible) mouse cursor in the middle of the screen, so it doesn't fly out in windowed mode and some other window gets clicked
+#ifdef __unix__
+					// Note - For the linux version the centering is partially done in the event loop, this just resets the allegro mouse position
 					position_mouse(_xwin.window_width / 2, _xwin.window_height / 2);
+#else
+					position_mouse(g_FrameMan.GetResX() / 2, g_FrameMan.GetResY() / 2);
+#endif
 				} else if (g_ActivityMan.IsInActivity()) {
 					// The mouse cursor is visible and can move about the screen/window, but it should still be contained within the mouse player's part of the window
 					ForceMouseWithinPlayerScreen(mousePlayer);

--- a/Managers/UInputMan.cpp
+++ b/Managers/UInputMan.cpp
@@ -35,7 +35,6 @@ namespace RTE {
 	JOYSTICK_INFO UInputMan::s_PrevJoystickStates[Players::MaxPlayerCount];
 	JOYSTICK_INFO UInputMan::s_ChangedJoystickStates[Players::MaxPlayerCount];
 
-
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 	void UInputMan::Clear() {
@@ -120,7 +119,6 @@ namespace RTE {
 		poll_joystick();
 
 		_xwin_input_handler = HandleAllegroMouseInput;
-		_xwin.hw_cursor_ok = TRUE;
 
 		return 0;
 	}
@@ -737,7 +735,6 @@ namespace RTE {
 		HandleSpecialInput();
 		StoreInputEventsForNextUpdate();
 
-
 		return 0;
 	}
 
@@ -989,6 +986,8 @@ namespace RTE {
 			}
 		}
 	}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #ifdef __unix__
 	void UInputMan::HandleAllegroMouseInput() {

--- a/Managers/UInputMan.cpp
+++ b/Managers/UInputMan.cpp
@@ -1050,6 +1050,11 @@ namespace RTE {
 		_xwin.mouse_warped = 0;
 		_xwin_private_handle_input();
 
+		if (g_UInputMan.m_TrapMousePos) {
+			mouse_x = _xwin.window_width / 2;
+			mouse_y = _xwin.window_height / 2;
+		}
+
 		_mouse_x = mouse_x;
 		_mouse_y = mouse_y;
 	}

--- a/Managers/UInputMan.cpp
+++ b/Managers/UInputMan.cpp
@@ -407,14 +407,19 @@ namespace RTE {
 
 	void UInputMan::TrapMousePos(bool trap, int whichPlayer) {
 		if (whichPlayer == Players::NoPlayer || m_ControlScheme.at(whichPlayer).GetDevice() == InputDevice::DEVICE_MOUSE_KEYB) {
+#ifdef __unix__
+			bool prevTrapStatus = m_TrapMousePos;
+#endif
 			m_TrapMousePos = trap;
 #ifdef __unix__
-			WarpMouse(_xwin.window_width / 2, _xwin.window_height / 2);
-			int discard;
-			get_mouse_mickeys(&discard, &discard);
-			get_mouse_mickeys(&discard, &discard);
-			get_mouse_mickeys(&discard, &discard);
-			WarpMouse(_xwin.window_width / 2, _xwin.window_height / 2);
+			if (m_TrapMousePos != prevTrapStatus) {
+				WarpMouse(_xwin.window_width / 2, _xwin.window_height / 2);
+				int discard;
+				get_mouse_mickeys(&discard, &discard);
+				get_mouse_mickeys(&discard, &discard);
+				get_mouse_mickeys(&discard, &discard);
+				WarpMouse(_xwin.window_width / 2, _xwin.window_height / 2);
+			}
 #endif
 		}
 		m_TrapMousePosPerPlayer[whichPlayer] = trap;

--- a/Managers/UInputMan.cpp
+++ b/Managers/UInputMan.cpp
@@ -118,7 +118,9 @@ namespace RTE {
 		if (install_joystick(JOY_TYPE_AUTODETECT) != 0) { RTEAbort("Failed to initialize joysticks!"); }
 		poll_joystick();
 
+#ifdef __unix__
 		_xwin_input_handler = HandleAllegroMouseInput;
+#endif
 
 		return 0;
 	}

--- a/Managers/UInputMan.cpp
+++ b/Managers/UInputMan.cpp
@@ -1065,7 +1065,6 @@ namespace RTE {
 		}
 		_mouse_x = mouse_x = x;
 		_mouse_y = mouse_y = y;
-
 	}
 #endif
 }

--- a/Managers/UInputMan.cpp
+++ b/Managers/UInputMan.cpp
@@ -720,6 +720,20 @@ namespace RTE {
 		int mickeyX;
 		int mickeyY;
 		get_mouse_mickeys(&mickeyX, &mickeyY);
+		static std::vector<std::pair<std::pair<int, int>,std::pair<int,int>>> mickeys(10);
+		static int nMickeys = 0;
+		mickeys[nMickeys] = {{mouse_x, mouse_y},{mickeyX, mickeyY}};
+		++nMickeys;
+		nMickeys %= 10;
+		if(mickeyX > 100 && mickeyY > 100) {
+			for (auto &mickey : mickeys){
+				std::cout << mickey.first.first << " : " << mickey.second.first << " | " << mickey.first.second << " : " << mickey.second.second << std::endl;
+			}
+
+			std::cout << "(" << mickeyX << " : " << mouse_x << " : " << _mouse_x << " | " << \
+				mickeyY << " : " << mouse_y << " : " << _mouse_y << ") hw: " << _xwin.hw_cursor_ok << " t: " << m_TrapMousePos << std::endl;
+		}
+
 		m_RawMouseMovement.SetXY(mickeyX, mickeyY);
 
 		// TODO: Add sensitivity slider to settings menu
@@ -875,7 +889,7 @@ namespace RTE {
 			if (!m_DisableMouseMoving && !IsInMultiplayerMode()) {
 				if (m_TrapMousePos) {
 					// Trap the (invisible) mouse cursor in the middle of the screen, so it doesn't fly out in windowed mode and some other window gets clicked
-					position_mouse(g_FrameMan.GetResX() / 2, g_FrameMan.GetResY() / 2);
+					//position_mouse(g_FrameMan.GetResX() / 2, g_FrameMan.GetResY() / 2);
 				} else if (g_ActivityMan.IsInActivity()) {
 					// The mouse cursor is visible and can move about the screen/window, but it should still be contained within the mouse player's part of the window
 					ForceMouseWithinPlayerScreen(mousePlayer);
@@ -1023,6 +1037,7 @@ namespace RTE {
 					if (g_UInputMan.m_TrapMousePos) {
 						XWarpPointer(_xwin.display, _xwin.window, _xwin.window, 0, 0, 0, 0, _xwin.window_width / 2, _xwin.window_height / 2);
 					}
+
 				} break;
 
 				default:

--- a/Managers/UInputMan.cpp
+++ b/Managers/UInputMan.cpp
@@ -720,19 +720,6 @@ namespace RTE {
 		int mickeyX;
 		int mickeyY;
 		get_mouse_mickeys(&mickeyX, &mickeyY);
-		static std::vector<std::pair<std::pair<int, int>,std::pair<int,int>>> mickeys(10);
-		static int nMickeys = 0;
-		mickeys[nMickeys] = {{mouse_x, mouse_y},{mickeyX, mickeyY}};
-		++nMickeys;
-		nMickeys %= 10;
-		if(mickeyX > 100 && mickeyY > 100) {
-			for (auto &mickey : mickeys){
-				std::cout << mickey.first.first << " : " << mickey.second.first << " | " << mickey.first.second << " : " << mickey.second.second << std::endl;
-			}
-
-			std::cout << "(" << mickeyX << " : " << mouse_x << " : " << _mouse_x << " | " << \
-				mickeyY << " : " << mouse_y << " : " << _mouse_y << ") hw: " << _xwin.hw_cursor_ok << " t: " << m_TrapMousePos << std::endl;
-		}
 
 		m_RawMouseMovement.SetXY(mickeyX, mickeyY);
 

--- a/Managers/UInputMan.cpp
+++ b/Managers/UInputMan.cpp
@@ -1023,17 +1023,19 @@ namespace RTE {
 		int dx = 0;
 		int dy = 0;
 
+		int halfResX = _xwin.window_width / 2;
+		int halfResY = _xwin.window_height / 2;
 		for (auto event = events.rbegin(); event < events.rend(); ++event) {
 			switch (event->type) {
 				case MotionNotify: {
 					dx = event->xmotion.x - mousePrevX;
 					dy = event->xmotion.y - mousePrevY;
 					_xwin_mouse_interrupt(dx, dy, 0, 0, mouse_b);
-					_mouse_x = mousePrevX = !g_UInputMan.m_TrapMousePos ? event->xmotion.x : _xwin.window_width / 2;
-					_mouse_y = mousePrevY = !g_UInputMan.m_TrapMousePos ? event->xmotion.y : _xwin.window_height / 2;
+					_mouse_x = mousePrevX = !g_UInputMan.m_TrapMousePos ? event->xmotion.x : halfResX;
+					_mouse_y = mousePrevY = !g_UInputMan.m_TrapMousePos ? event->xmotion.y : halfResY;
 
-					if (g_UInputMan.m_TrapMousePos) {
-						XWarpPointer(_xwin.display, _xwin.window, _xwin.window, 0, 0, 0, 0, _xwin.window_width / 2, _xwin.window_height / 2);
+					if (g_UInputMan.m_TrapMousePos && (dx != 0 || dy != 0)) {
+						XWarpPointer(_xwin.display, _xwin.window, _xwin.window, 0, 0, 0, 0, halfResX, halfResY);
 					}
 				} break;
 
@@ -1058,10 +1060,12 @@ namespace RTE {
 	}
 
 	void UInputMan::WarpMouse(int x, int y) const {
+		if (mouse_x != x || mouse_y != y) {
+			XWarpPointer(_xwin.display, _xwin.window, _xwin.window, 0, 0, 0, 0, x, y);
+		}
 		_mouse_x = mouse_x = x;
 		_mouse_y = mouse_y = y;
 
-		XWarpPointer(_xwin.display, _xwin.window, _xwin.window, 0, 0, 0, 0, x, y);
 	}
 #endif
 }

--- a/Managers/UInputMan.cpp
+++ b/Managers/UInputMan.cpp
@@ -408,6 +408,14 @@ namespace RTE {
 	void UInputMan::TrapMousePos(bool trap, int whichPlayer) {
 		if (whichPlayer == Players::NoPlayer || m_ControlScheme.at(whichPlayer).GetDevice() == InputDevice::DEVICE_MOUSE_KEYB) {
 			m_TrapMousePos = trap;
+#ifdef __unix__
+			WarpMouse(_xwin.window_width / 2, _xwin.window_height / 2);
+			int discard;
+			get_mouse_mickeys(&discard, &discard);
+			get_mouse_mickeys(&discard, &discard);
+			get_mouse_mickeys(&discard, &discard);
+			WarpMouse(_xwin.window_width / 2, _xwin.window_height / 2);
+#endif
 		}
 		m_TrapMousePosPerPlayer[whichPlayer] = trap;
 	}

--- a/Managers/UInputMan.cpp
+++ b/Managers/UInputMan.cpp
@@ -1039,14 +1039,13 @@ namespace RTE {
 		_xwin.mouse_warped = 0;
 		_xwin_private_handle_input();
 
-		if(g_UInputMan.m_TrapMousePos){
+		if (g_UInputMan.m_TrapMousePos) {
 			mouse_x = _xwin.window_width / 2;
 			mouse_y = _xwin.window_height / 2;
 		}
 
 		_mouse_x = mouse_x;
 		_mouse_y = mouse_y;
-
 	}
 #endif
 }

--- a/Managers/UInputMan.cpp
+++ b/Managers/UInputMan.cpp
@@ -13,8 +13,7 @@
 
 #ifdef _WIN32
 #include "joystickapi.h"
-#endif
-#ifdef __unix__
+#elif __unix__
 #include <fcntl.h>
 #include "allegro/internal/aintern.h"
 #include "allegro/platform/aintunix.h"
@@ -101,12 +100,10 @@ namespace RTE {
 			}
 		}
 
-
 #ifdef __unix__
 		m_AllegroMousePreviousX = 0;
 		m_AllegroMousePreviousY = 0;
 #endif
-
 	}
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1056,13 +1053,11 @@ namespace RTE {
 					}
 					break;
 				}
-
 				default:
 					XPutBackEvent(_xwin.display, &(*event));
 					break;
 			}
 		}
-
 		XFlush(_xwin.display);
 
 		_xwin.mouse_warped = 0;
@@ -1072,7 +1067,6 @@ namespace RTE {
 			mouse_x = _xwin.window_width / 2;
 			mouse_y = _xwin.window_height / 2;
 		}
-
 		_mouse_x = mouse_x;
 		_mouse_y = mouse_y;
 	}
@@ -1080,9 +1074,7 @@ namespace RTE {
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 	void UInputMan::WarpMouse(int x, int y) const {
-		if (mouse_x != x || mouse_y != y) {
-			XWarpPointer(_xwin.display, _xwin.window, _xwin.window, 0, 0, 0, 0, x, y);
-		}
+		if (mouse_x != x || mouse_y != y) { XWarpPointer(_xwin.display, _xwin.window, _xwin.window, 0, 0, 0, 0, x, y); }
 		_mouse_x = mouse_x = x;
 		_mouse_y = mouse_y = y;
 	}

--- a/Managers/UInputMan.cpp
+++ b/Managers/UInputMan.cpp
@@ -394,7 +394,7 @@ namespace RTE {
 #ifndef __unix__
 			position_mouse(static_cast<int>(newPos.GetX()), static_cast<int>(newPos.GetY()));
 #else
-			WarpMouse(newPos.m_X, newPos.m_Y);
+			WarpMouse(newPos.m_X * g_FrameMan.GetResMultiplier(), newPos.m_Y * g_FrameMan.GetResMultiplier());
 #endif
 		}
 	}

--- a/Managers/UInputMan.cpp
+++ b/Managers/UInputMan.cpp
@@ -889,7 +889,7 @@ namespace RTE {
 			if (!m_DisableMouseMoving && !IsInMultiplayerMode()) {
 				if (m_TrapMousePos) {
 					// Trap the (invisible) mouse cursor in the middle of the screen, so it doesn't fly out in windowed mode and some other window gets clicked
-					//position_mouse(g_FrameMan.GetResX() / 2, g_FrameMan.GetResY() / 2);
+					position_mouse(_xwin.window_width / 2, _xwin.window_height / 2);
 				} else if (g_ActivityMan.IsInActivity()) {
 					// The mouse cursor is visible and can move about the screen/window, but it should still be contained within the mouse player's part of the window
 					ForceMouseWithinPlayerScreen(mousePlayer);

--- a/Managers/UInputMan.cpp
+++ b/Managers/UInputMan.cpp
@@ -1050,11 +1050,6 @@ namespace RTE {
 		_xwin.mouse_warped = 0;
 		_xwin_private_handle_input();
 
-		if (g_UInputMan.m_TrapMousePos) {
-			mouse_x = _xwin.window_width / 2;
-			mouse_y = _xwin.window_height / 2;
-		}
-
 		_mouse_x = mouse_x;
 		_mouse_y = mouse_y;
 	}

--- a/Managers/UInputMan.h
+++ b/Managers/UInputMan.h
@@ -803,7 +803,7 @@ namespace RTE {
 		static void HandleAllegroMouseInput(void);
 
 		/// <summary>
-		/// Position the mouse on the screen in window coordinates. Correctly generates MouseMotion events. Replaces position_mouse.
+		/// Position the mouse on the screen in window coordinates. Generates MouseMotion events iff the requested position is different from the actual mouse position. Replaces position_mouse.
 		/// </summary>
 		/// <param name="x">
 		/// The x coordinate to warp to.

--- a/Managers/UInputMan.h
+++ b/Managers/UInputMan.h
@@ -797,18 +797,20 @@ namespace RTE {
 		UInputMan & operator=(const UInputMan &rhs) = delete;
 
 #ifdef __unix__
-	private:
-
 		int m_AllegroMousePreviousX; //!< Stored mouse x position for the allegro event handler.
 		int m_AllegroMousePreviousY; //!< Stored mouse y position for the allegro event handler.
 
 		/// <summary>
+		/// Necessary static handler method ensuring mouse inputs work well on Linux. Must be applied to _xwin_input_handler when manager is initialized.
+		/// </summary>
+		static void XWinInputHandlerOverride() { g_UInputMan.HandleAllegroMouseInput(); }
+
+		/// <summary>
 		/// Mouse input handler to circumvent the input drops that allegro does regularly, by replacing and disabling the default warping behaviour.
 		/// Motion events that are generated while the handler is working are offset such that the allegro driver doesn't mess up the mickeys.
-		/// This also handles the centering warp for relative mouse motion.
-		/// Should be applied to _xwin_input_handler. Might not run in the main thread, depending on how allegro was built.
+		/// This also handles the centering warp for relative mouse motion. Might not run in the main thread, depending on how allegro was built.
 		/// </summary>
-		static void HandleAllegroMouseInput(void);
+		void HandleAllegroMouseInput();
 
 		/// <summary>
 		/// Position the mouse on the screen in window coordinates. Generates MouseMotion events if the requested position is different from the actual mouse position.

--- a/Managers/UInputMan.h
+++ b/Managers/UInputMan.h
@@ -798,12 +798,13 @@ namespace RTE {
 
 #ifdef __unix__
 		/// <summary>
-		/// Mouse input handler to circumvent the input drops that allegro does regularly.
+		/// Mouse input handler to circumvent the input drops that allegro does regularly. Should be applied to _xwin_input_handler.
 		/// </summary>
 		static void HandleAllegroMouseInput(void);
 
 		/// <summary>
-		/// Position the mouse on the screen in window coordinates. Generates MouseMotion events iff the requested position is different from the actual mouse position. Replaces position_mouse.
+		/// Position the mouse on the screen in window coordinates. Generates MouseMotion events iff the requested position is different from the actual mouse position.
+		/// Replaces position_mouse.
 		/// </summary>
 		/// <param name="x">
 		/// The x coordinate to warp to.

--- a/Managers/UInputMan.h
+++ b/Managers/UInputMan.h
@@ -806,15 +806,15 @@ namespace RTE {
 		static void XWinInputHandlerOverride() { g_UInputMan.HandleAllegroMouseInput(); }
 
 		/// <summary>
-		/// Mouse input handler to circumvent the input drops that allegro does regularly, by replacing and disabling the default warping behaviour.
-		/// Motion events that are generated while the handler is working are offset such that the allegro driver doesn't mess up the mickeys.
-		/// This also handles the centering warp for relative mouse motion. Might not run in the main thread, depending on how allegro was built.
+		/// Mouse input handler to circumvent the input drops that Allegro does regularly, by replacing and disabling the default warping behavior.
+		/// Motion events that are generated while the handler is working are offset such that the Allegro driver doesn't mess up the mickeys.
+		/// This also handles the centering warp for relative mouse motion. Might not run in the main thread, depending on how Allegro was built.
 		/// </summary>
 		void HandleAllegroMouseInput();
 
 		/// <summary>
 		/// Position the mouse on the screen in window coordinates. Generates MouseMotion events if the requested position is different from the actual mouse position.
-		/// Replaces position_mouse and sets the allegro internal mouse position to the requested x,y.
+		/// Replaces position_mouse and sets the Allegro internal mouse position to the requested coordinates.
 		/// </summary>
 		/// <param name="x"> The x coordinate to warp to. </param>
 		/// <param name="y"> The y coordinate to warp to. </param>

--- a/Managers/UInputMan.h
+++ b/Managers/UInputMan.h
@@ -797,6 +797,11 @@ namespace RTE {
 		UInputMan & operator=(const UInputMan &rhs) = delete;
 
 #ifdef __unix__
+	private:
+
+		int m_AllegroMousePreviousX; //!< Stored mouse x position for the allegro event handler.
+		int m_AllegroMousePreviousY; //!< Stored mouse y position for the allegro event handler.
+
 		/// <summary>
 		/// Mouse input handler to circumvent the input drops that allegro does regularly, by replacing and disabling the default warping behaviour.
 		/// Motion events that are generated while the handler is working are offset such that the allegro driver doesn't mess up the mickeys.
@@ -806,15 +811,11 @@ namespace RTE {
 		static void HandleAllegroMouseInput(void);
 
 		/// <summary>
-		/// Position the mouse on the screen in window coordinates. Generates MouseMotion events iff the requested position is different from the actual mouse position.
+		/// Position the mouse on the screen in window coordinates. Generates MouseMotion events if the requested position is different from the actual mouse position.
 		/// Replaces position_mouse and sets the allegro internal mouse position to the requested x,y.
 		/// </summary>
-		/// <param name="x">
-		/// The x coordinate to warp to.
-		/// </param>
-		/// <param name="y">
-		/// The y coordinate to warp to.
-		/// </param>
+		/// <param name="x"> The x coordinate to warp to. </param>
+		/// <param name="y"> The y coordinate to warp to. </param>
 		void WarpMouse(int x, int y) const;
 #endif
 	};

--- a/Managers/UInputMan.h
+++ b/Managers/UInputMan.h
@@ -795,6 +795,10 @@ namespace RTE {
 		// Disallow the use of some implicit methods.
 		UInputMan(const UInputMan &reference) = delete;
 		UInputMan & operator=(const UInputMan &rhs) = delete;
+
+#ifdef __unix__
+		static void HandleAllegroMouseInput(void);
+#endif
 	};
 }
 #endif

--- a/Managers/UInputMan.h
+++ b/Managers/UInputMan.h
@@ -801,6 +801,17 @@ namespace RTE {
 		/// Mouse input handler to circumvent the input drops that allegro does regularly.
 		/// </summary>
 		static void HandleAllegroMouseInput(void);
+
+		/// <summary>
+		/// Position the mouse on the screen in window coordinates. Correctly generates MouseMotion events. Replaces position_mouse.
+		/// </summary>
+		/// <param name="x">
+		/// The x coordinate to warp to.
+		/// </param>
+		/// <param name="y">
+		/// The y coordinate to warp to.
+		/// </param>
+		void WarpMouse(int x, int y) const;
 #endif
 	};
 }

--- a/Managers/UInputMan.h
+++ b/Managers/UInputMan.h
@@ -801,7 +801,7 @@ namespace RTE {
 		/// Mouse input handler to circumvent the input drops that allegro does regularly, by replacing and disabling the default warping behaviour.
 		/// Motion events that are generated while the handler is working are offset such that the allegro driver doesn't mess up the mickeys.
 		/// This also handles the centering warp for relative mouse motion.
-		/// Should be applied to _xwin_input_handler.
+		/// Should be applied to _xwin_input_handler. Might not run in the main thread, depending on how allegro was built.
 		/// </summary>
 		static void HandleAllegroMouseInput(void);
 

--- a/Managers/UInputMan.h
+++ b/Managers/UInputMan.h
@@ -798,13 +798,16 @@ namespace RTE {
 
 #ifdef __unix__
 		/// <summary>
-		/// Mouse input handler to circumvent the input drops that allegro does regularly. Should be applied to _xwin_input_handler.
+		/// Mouse input handler to circumvent the input drops that allegro does regularly, by replacing and disabling the default warping behaviour.
+		/// Motion events that are generated while the handler is working are offset such that the allegro driver doesn't mess up the mickeys.
+		/// This also handles the centering warp for relative mouse motion.
+		/// Should be applied to _xwin_input_handler.
 		/// </summary>
 		static void HandleAllegroMouseInput(void);
 
 		/// <summary>
 		/// Position the mouse on the screen in window coordinates. Generates MouseMotion events iff the requested position is different from the actual mouse position.
-		/// Replaces position_mouse.
+		/// Replaces position_mouse and sets the allegro internal mouse position to the requested x,y.
 		/// </summary>
 		/// <param name="x">
 		/// The x coordinate to warp to.

--- a/Managers/UInputMan.h
+++ b/Managers/UInputMan.h
@@ -797,6 +797,9 @@ namespace RTE {
 		UInputMan & operator=(const UInputMan &rhs) = delete;
 
 #ifdef __unix__
+		/// <summary>
+		/// Mouse input handler to circumvent the input drops that allegro does regularly.
+		/// </summary>
 		static void HandleAllegroMouseInput(void);
 #endif
 	};

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ The Linux build uses the meson build system, and builds against system libraries
 * `libX11`
 * [`meson`](https://www.mesonbuild.com)`>= 0.53` (If your distro doesn't have a recent version of meson, use the pip version instead)
 * `boost>=1.55`
+* (optional) `xmessage`
 
 ## Building
 
@@ -97,13 +98,17 @@ If you want to change the buildtype afterwards, you can use `meson configure --b
 ## Installing Dependencies
 
 **Arch Linux:**  
-`# pacman -S allegro4 boost flac luajit minizip lz4 libpng libx11 meson ninja base-devel`
+`# pacman -S allegro4 boost flac luajit minizip lz4 libpng libx11 xorg-xmessage meson ninja base-devel`
 
 **Ubuntu >=20.04:**  
 `# apt-get install build-essential libboost-dev liballegro4-dev libloadpng4-dev libflac++-dev luajit-5.1-dev libminizip-dev liblz4-dev libpng++-dev libx11-dev ninja-build meson`  
 ## Troubleshooting
 
-On some distros some keyboards and mice are recognized as controllers, to fix this follow these instructions: [https://github.com/denilsonsa/udev-joystick-blacklist](https://github.com/denilsonsa/udev-joystick-blacklist)
+* On some distros some keyboards and mice are recognized as controllers, to fix this follow these instructions: [https://github.com/denilsonsa/udev-joystick-blacklist](https://github.com/denilsonsa/udev-joystick-blacklist)
+
+* `pipewire(-alsa)` and fmod don't work well together, so the game might [not close or have no sound or crash](https://gitlab.freedesktop.org/pipewire/pipewire/-/issues/1514). Workaround by `ln -s /bin/true /usr/bin/pulseaudio`
+
+* Gamepad triggers may be inverted, to work around that: Hold down the trigger, select the input you want it assigned to and release to assign it, then it will be correct in use.
 
 ***
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ If you want to change the buildtype afterwards, you can use `meson configure --b
 
 * On some distros some keyboards and mice are recognized as controllers, to fix this follow these instructions: [https://github.com/denilsonsa/udev-joystick-blacklist](https://github.com/denilsonsa/udev-joystick-blacklist)
 
-* `pipewire(-alsa)` and fmod don't work well together, so the game might [not close or have no sound or crash](https://gitlab.freedesktop.org/pipewire/pipewire/-/issues/1514). Workaround by `ln -s /bin/true /usr/bin/pulseaudio`
+* `pipewire(-alsa)` and fmod don't work well together, so the game might [not close, have no sound or crash](https://gitlab.freedesktop.org/pipewire/pipewire/-/issues/1514). Workaround by `ln -s /bin/true /usr/bin/pulseaudio`
 
 * Gamepad triggers may be inverted, to work around that: Hold down the trigger, select the input you want it assigned to and release to assign it, then it will be correct in use.
 


### PR DESCRIPTION
fixes \\/

https://user-images.githubusercontent.com/8429918/144914772-780958f5-52a5-476d-846c-bb6ea3ceabfd.mp4

- Fixed by intercepting mouse input events before passing everything else to allegro, though some mouse inputs (events generated while the intercept is running, including centering warps) go through, since this is usually running in a separate thread. To stop allegro from then breaking everything, also disables allegros incorrectly implemented mouse warping.

- Added replacements for position_mouse because that was also breaking things, and moved mouse trapping to the event handler.