### PR TITLE
[Linux] add explicit lua5.2 dependency for luajit2.1/moonjit compatibility

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Dependencies
         run: |
           sudo apt-get update -yq
-          sudo apt-get install --no-install-recommends liballegro4-dev libloadpng4-dev libflac++-dev luajit-5.1-dev libminizip-dev liblz4-dev libpng++-dev libx11-dev libboost-dev
+          sudo apt-get install --no-install-recommends liballegro4-dev libloadpng4-dev libflac++-dev luajit-5.1-dev liblua5.2-dev libminizip-dev liblz4-dev libpng++-dev libx11-dev libboost-dev
 
       - name: Install Clang
         # You may pin to the exact commit or the version.

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Dependencies
         run: |
           sudo apt-get update -yq
-          sudo apt-get install --no-install-recommends wget liballegro4-dev libloadpng4-dev libflac++-dev luajit-5.1-dev libminizip-dev liblz4-dev libpng++-dev libx11-dev libboost-dev
+          sudo apt-get install --no-install-recommends wget liballegro4-dev libloadpng4-dev libflac++-dev luajit-5.1-dev liblua5.2-dev libminizip-dev liblz4-dev libpng++-dev libx11-dev libboost-dev
 
       - name: Install Clang
         # You may pin to the exact commit or the version.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ If you want to change the buildtype afterwards, you can use `meson configure --b
 `# pacman -S allegro4 boost flac luajit lua52 minizip lz4 libpng libx11 xorg-xmessage meson ninja base-devel`
 
 **Ubuntu >=20.04:**  
-`# apt-get install build-essential libboost-dev liballegro4-dev libloadpng4-dev libflac++-dev luajit-5.1-dev libminizip-dev liblz4-dev libpng++-dev libx11-dev ninja-build meson`  
+`# apt-get install build-essential libboost-dev liballegro4-dev libloadpng4-dev libflac++-dev luajit-5.1-dev liblua5.2-dev libminizip-dev liblz4-dev libpng++-dev libx11-dev ninja-build meson`  
 ## Troubleshooting
 
 * On some distros some keyboards and mice are recognized as controllers, to fix this follow these instructions: [https://github.com/denilsonsa/udev-joystick-blacklist](https://github.com/denilsonsa/udev-joystick-blacklist)

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The Linux build uses the meson build system, and builds against system libraries
 * `loadpng`
 * `flac`
 * `luajit`
+  * `lua5.2` (if luajit >=2.1)
 * `minizip`
 * `lz4>=1.9.0`
 * `libpng`
@@ -96,7 +97,7 @@ If you want to change the buildtype afterwards, you can use `meson configure --b
 ## Installing Dependencies
 
 **Arch Linux:**  
-`# pacman -S allegro4 boost flac luajit minizip lz4 libpng libx11 xorg-xmessage meson ninja base-devel`
+`# pacman -S allegro4 boost flac luajit lua52 minizip lz4 libpng libx11 xorg-xmessage meson ninja base-devel`
 
 **Ubuntu >=20.04:**  
 `# apt-get install build-essential libboost-dev liballegro4-dev libloadpng4-dev libflac++-dev luajit-5.1-dev libminizip-dev liblz4-dev libpng++-dev libx11-dev ninja-build meson`  

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The Linux build uses the meson build system, and builds against system libraries
 * `loadpng`
 * `flac`
 * `luajit`
-  * `lua5.2` (if luajit >=2.1)
+* `lua5.2`
 * `minizip`
 * `lz4>=1.9.0`
 * `libpng`

--- a/meson.build
+++ b/meson.build
@@ -9,16 +9,13 @@ if host_machine.system() in ['linux','osx']
     dependency('loadpng'),
     dependency('flac'),
     dependency('minizip'),
+    dependency('luajit'),
+    dependency('lua52'),
     dependency('threads'),
     dependency('liblz4'),
     dependency('libpng'),
     dependency('boost'), #needed for luabind
   ]
-  luajit = dependency('luajit')
-  deps += luajit
-  if luajit.version() >= '2.1'
-    deps += dependency('lua52')
-  endif
   if host_machine.system() == 'linux'
     deps += dependency('x11')
   endif

--- a/meson.build
+++ b/meson.build
@@ -8,13 +8,17 @@ if host_machine.system() in ['linux','osx']
     dependency('allegro'),
     dependency('loadpng'),
     dependency('flac'),
-    dependency('luajit'),
     dependency('minizip'),
     dependency('threads'),
     dependency('liblz4'),
     dependency('libpng'),
     dependency('boost'), #needed for luabind
   ]
+  luajit = dependency('luajit')
+  deps += luajit
+  if luajit.version() >= '2.1'
+    deps += dependency('lua52')
+  endif
   if host_machine.system() == 'linux'
     deps += dependency('x11')
   endif


### PR DESCRIPTION
With luajit 2.1 now in use by major distros, we have an explicit dependency on lua5.2