### PR TITLE
Change "How to Play" to "Install"

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,10 @@ Stay up to date in our [Discord channel](https://discord.gg/TSU6StNQUG).
 ***
 
 # Installing the Game
-If you just want to play the latest version of the game you can get it from our [website](https://cortex-command-community.github.io), and you can get mods from our [mod portal](https://cccp.mod.io).
+If you just want to play the latest version of the game you can get it from our [website](https://cortex-command-community.github.io).
+
+# Getting Mods
+You can get mods from our [mod portal](https://cccp.mod.io).
 
 ***
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Stay up to date in our [Discord channel](https://discord.gg/TSU6StNQUG).
 ***
 
 # Installing the Game
-If you just want to play the latest version of the game you can get it from our [website](https://cortex-command-community.github.io).
+If you just want to play the latest version of the game you can get it from our [website](https://cortex-command-community.github.io/downloads).
 
 # Getting Mods
 You can get mods from our [mod portal](https://cccp.mod.io).

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Stay up to date in our [Discord channel](https://discord.gg/TSU6StNQUG).
 
 ***
 
-# How to Play the Game
+# Installing the Game
 If you just want to play the latest version of the game you can get it from our [website](https://cortex-command-community.github.io), and you can get mods from our [mod portal](https://cccp.mod.io).
 
 ***


### PR DESCRIPTION
I have a friend who made the remark that "How to Play" implies a tutorial on how to beat the game, instead of being about how to install the game.