### PR TITLE
Added ACDropShip property HoverHeightModifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 <details><summary><b>Added</b></summary>
+
+- New INI and Lua (R/W) `ACDropShip` property `HoverHeightModifier`. This allows for modification of the height at which an `ACDropShip` will hover when unloading cargo, or staying at a location.
+
 </details>
 
 <details><summary><b>Changed</b></summary>

--- a/Entities/ACDropShip.cpp
+++ b/Entities/ACDropShip.cpp
@@ -319,7 +319,7 @@ void ACDropShip::UpdateAI()
     float angle = m_Rotation.GetRadAngle();
 
     // This is the altitude at which the craft will hover and unload its cargo
-    float hoverAltitude = m_CharHeight * 2 + GetHoverHeightModifier();
+    float hoverAltitude = m_CharHeight * 2 + m_HoverHeightModifier;
     // The gutter range threshold for how much above and below the hovering altitude is ok to stay in
     float hoverRange = m_CharHeight / 4;
     // Get the altitude reading, within 25 pixels precision

--- a/Entities/ACDropShip.cpp
+++ b/Entities/ACDropShip.cpp
@@ -319,7 +319,7 @@ void ACDropShip::UpdateAI()
     float angle = m_Rotation.GetRadAngle();
 
     // This is the altitude at which the craft will hover and unload its cargo
-    float hoverAltitude = m_CharHeight * 2;
+    float hoverAltitude = m_CharHeight * 2 + GetHoverHeightModifier();
     // The gutter range threshold for how much above and below the hovering altitude is ok to stay in
     float hoverRange = m_CharHeight / 4;
     // Get the altitude reading, within 25 pixels precision

--- a/Entities/ACDropShip.cpp
+++ b/Entities/ACDropShip.cpp
@@ -44,6 +44,7 @@ void ACDropShip::Clear()
 	m_LateralControlSpeed = 6.0f;
 	m_AutoStabilize = 1;
 	m_MaxEngineAngle = 20.0f;
+	m_HoverHeightModifier = 0;
 }
 
 
@@ -98,6 +99,8 @@ int ACDropShip::Create(const ACDropShip &reference) {
 
 	m_MaxEngineAngle = reference.m_MaxEngineAngle;
 
+	m_HoverHeightModifier = reference.m_HoverHeightModifier;
+
 	return 0;
 }
 
@@ -129,8 +132,10 @@ int ACDropShip::ReadProperty(const std::string_view &propName, Reader &reader) {
         reader >> m_AutoStabilize;
     } else if (propName == "MaxEngineAngle") {
         reader >> m_MaxEngineAngle;
-    } else if (propName == "LateralControlSpeed") {
-        reader >> m_LateralControlSpeed;
+	} else if (propName == "LateralControlSpeed") {
+		reader >> m_LateralControlSpeed;
+	} else if (propName == "HoverHeightModifier") {
+		reader >> m_HoverHeightModifier;
     } else {
         return ACraft::ReadProperty(propName, reader);
     }
@@ -169,6 +174,7 @@ int ACDropShip::Save(Writer &writer) const
 	writer << m_MaxEngineAngle;
 	writer.NewProperty("LateralControlSpeed");
 	writer << m_LateralControlSpeed;
+	writer.NewPropertyWithValue("HoverHeightModifier", m_HoverHeightModifier);
 
     return 0;
 }

--- a/Entities/ACDropShip.h
+++ b/Entities/ACDropShip.h
@@ -296,6 +296,18 @@ ClassInfoGetters;
 
 	float GetLateralControl() const { return m_LateralControl; }
 
+	/// <summary>
+	/// Gets the modifier for height at which this ACDropship should hover above terrain.
+	/// </summary>
+	/// <returns>The modifier for height at which this ACDropship should hover above terrain.</returns>
+	float GetHoverHeightModifier() const { return m_HoverHeightModifier; }
+
+	/// <summary>
+	/// Sets the modifier for height at which this ACDropship should hover above terrain.
+	/// </summary>
+	/// <param name="newHoverHeightModifier">The new modifier for height at which this ACDropship should hover above terrain.</param>
+	void SetHoverHeightModifier(float newHoverHeightModifier) { m_HoverHeightModifier = newHoverHeightModifier; }
+
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // Protected member variable and method declarations
@@ -332,6 +344,8 @@ protected:
 
 	// Maximum engine rotation in degrees
 	float m_MaxEngineAngle;
+
+	float m_HoverHeightModifier;
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // Private member variable and method declarations

--- a/Entities/ACDropShip.h
+++ b/Entities/ACDropShip.h
@@ -345,7 +345,7 @@ protected:
 	// Maximum engine rotation in degrees
 	float m_MaxEngineAngle;
 
-	float m_HoverHeightModifier;
+	float m_HoverHeightModifier; //!< The modifier for the height at which this ACDropShip should hover above terrain when releasing its cargo. Used in cpp and Lua AI.
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // Private member variable and method declarations

--- a/Lua/LuaBindingsEntities.cpp
+++ b/Lua/LuaBindingsEntities.cpp
@@ -40,6 +40,7 @@ namespace RTE {
 		.property("MaxEngineAngle", &ACDropShip::GetMaxEngineAngle, &ACDropShip::SetMaxEngineAngle)
 		.property("LateralControlSpeed", &ACDropShip::GetLateralControlSpeed, &ACDropShip::SetLateralControlSpeed)
 		.property("LateralControl", &ACDropShip::GetLateralControl)
+		.property("HoverHeightModifier", &ACDropShip::GetHoverHeightModifier, &ACDropShip::SetHoverHeightModifier)
 
 		.def("DetectObstacle", &ACDropShip::DetectObstacle)
 		.def("GetAltitude", &ACDropShip::GetAltitude);


### PR DESCRIPTION
Community requested feature. Also helps with basegame dropships dropping stuff off too high up cause they use radius/diameter instead of individual radius/diameter