### PR TITLE
Meson Cleanup

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -52,8 +52,8 @@ jobs:
         with:
           # The action to run
           setup-options: --buildtype=debug -Ddebug_type=full
-          meson-version: 0.55.3
-          ninja-version: 1.10.0
+          meson-version: 0.60.0
+          ninja-version: 1.10.2
           action: build
 
   build-windows:

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -52,8 +52,8 @@ jobs:
         with:
           # The action to run
           setup-options: --buildtype=release -Dinstall_data=false -Dinstall_runner=false -Dfmod_dir=/usr/lib/ --prefix=/usr/
-          meson-version: 0.55.3
-          ninja-version: 1.10.0
+          meson-version: 0.60.0
+          ninja-version: 1.10.2
           action: build
 
       - name: Create AppDir

--- a/meson.build
+++ b/meson.build
@@ -8,7 +8,7 @@ if host_machine.system() in ['linux','osx']
     dependency('allegro', version:'<5.0'),
     dependency('loadpng'),
     dependency('flac'),
-    dependency('minizip', version:'<1.3', not_found_message:'The correct version of minizip might be packaged as minizip-compat.'),
+    dependency('minizip', version:'<1.3', not_found_message:'The correct version (1.2.x) of minizip might be packaged as minizip-compat.'),
     dependency('luajit'),
     dependency('threads'),
     dependency('liblz4'),
@@ -145,8 +145,8 @@ cccpelf = executable(
   cpp_args:[extra_args, preprocessor_flags], link_args:link_args, build_rpath:build_rpath,               # Compiler setup
   name_suffix:suffix,   # Executable name options
   build_by_default:true, # Meson options
-  gui_app:true,
-  install: true, install_rpath: install_rpath, install_dir: get_option('install_runner') ? get_option('libdir')/'CortexCommand' : get_option('bindir')
+  install: true, install_rpath: install_rpath, install_dir: get_option('install_runner') ? get_option('libdir')/'CortexCommand' : get_option('bindir'),
+  win_subsystem:'windows' # Windows mark as GUI app
 )
 
 #### Installing #####

--- a/meson.build
+++ b/meson.build
@@ -1,20 +1,20 @@
-project('Cortex-Command-Community-Project', ['cpp','c'], default_options:['cpp_std=c++17', 'buildtype=release'], version:'0.1.0-Pre-4.1', meson_version:'>=0.53')
+project('Cortex-Command-Community-Project', ['cpp','c'], default_options:['cpp_std=c++17', 'buildtype=release'], version:'0.1.0-Pre-4.1', meson_version:'>=0.60')
 
 #### Build environment Setup ####
 
 deps=[]
 if host_machine.system() in ['linux','osx']
   deps = [
-    dependency('allegro'),
+    dependency('allegro', version:'<5.0'),
     dependency('loadpng'),
     dependency('flac'),
-    dependency('minizip', version:'<1.3'),
+    dependency('minizip', version:'<1.3', not_found_message:'The correct version of minizip might be packaged as minizip-compat.'),
     dependency('luajit'),
-    dependency('lua52'),
     dependency('threads'),
     dependency('liblz4'),
     dependency('libpng'),
     dependency('boost'), #needed for luabind
+    dependency(['lua52', 'lua5.2', 'lua-5.2']),
   ]
   if host_machine.system() == 'linux'
     deps += dependency('x11')

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('CCOSS-community', ['cpp','c'], default_options:['cpp_std=c++17', 'buildtype=release'], version:'0.1.0-Pre-3.1', meson_version:'>=0.53')
+project('Cortex-Command-Community-Project', ['cpp','c'], default_options:['cpp_std=c++17', 'buildtype=release'], version:'0.1.0-Pre-4.1', meson_version:'>=0.53')
 
 #### Build environment Setup ####
 
@@ -94,7 +94,7 @@ endif
 conf_data = configuration_data()
 prefix = get_option('prefix')
 
-conf_data.set_quoted('BASEDATAPATH', prefix/get_option('data_install_dir'), strip_directory:true)
+conf_data.set_quoted('BASEDATAPATH', prefix/get_option('data_install_dir'))
 if suffix==''
   suffix=[]
   conf_data.set('EXENAME', elfname)

--- a/meson.build
+++ b/meson.build
@@ -8,7 +8,7 @@ if host_machine.system() in ['linux','osx']
     dependency('allegro'),
     dependency('loadpng'),
     dependency('flac'),
-    dependency('minizip'),
+    dependency('minizip', version:'<1.3'),
     dependency('luajit'),
     dependency('lua52'),
     dependency('threads'),


### PR DESCRIPTION
Some preventative maintenance:
- Fixed syntax error that somehow was not caught before meson 0.62
- Bumped meson minimum version to 0.60 (following current ubuntu-lts, actions stays as previous lts) and adjusted syntax
- Added fallback aliases for lua5.2 because there is no consensus on naming the pkgconfig file between distros
- Added version requirements to some dependencies (especially minizip) because some distros have weird naming conventions