### PR TITLE
[Linux] Misc warnings cleanup

### DIFF
--- a/Lua/LuaAdapters.h
+++ b/Lua/LuaAdapters.h
@@ -6,6 +6,8 @@
 
 #include "HeldDevice.h"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
 namespace RTE {
 
 #pragma region Manager Lua Adapters
@@ -127,4 +129,5 @@ namespace RTE {
 	}
 #pragma endregion
 }
+#pragma GCC diagnostic pop
 #endif

--- a/Lua/LuaAdaptersEntities.h
+++ b/Lua/LuaAdaptersEntities.h
@@ -42,6 +42,8 @@
 #include "GameActivity.h"
 #include "GAScripted.h"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
 namespace RTE {
 
 #pragma region Entity Lua Adapter Macros
@@ -315,4 +317,5 @@ namespace RTE {
 	LuaPropertyOwnershipSafetyFaker(HDFirearm, SoundContainer, SetReloadEndSound);
 #pragma endregion
 }
+#pragma GCC diagnostic pop
 #endif

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The Linux build uses the meson build system, and builds against system libraries
 * `lz4>=1.9.0`
 * `libpng`
 * `libX11`
-* [`meson`](https://www.mesonbuild.com)`>= 0.53` (If your distro doesn't have a recent version of meson, use the pip version instead)
+* [`meson`](https://www.mesonbuild.com)`>= 0.60` (`pip install meson=0.63.0 ninja=1.11.0` if your distro doesn't include a recent version)
 * `boost>=1.55`
 * (optional) `xmessage`
 

--- a/meson.build
+++ b/meson.build
@@ -42,7 +42,11 @@ if compiler.get_argument_syntax()== 'gcc' # used for gcc compatible compilers
   if buildtype_debug
 
     elfname += '_debug' # add _debug suffix for debug builds
-    extra_args = ['-Wno-unknown-pragmas'] # Disable #pragma region complaints
+    extra_args += ['-Wno-unknown-pragmas', '-Wno-deprecated-declarations'] # Disable #pragma region complaints and luabind auto_ptr warning
+
+    if get_option('sane_warnings')
+      extra_args += ['-Wno-sign-compare', '-Wno-non-virtual-dtor', '-Wno-parentheses', '-Wno-overloaded-virtual']
+    endif
 
     debug_type = get_option('debug_type')
     if debug_type == 'release'

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -5,3 +5,4 @@ option('install_fmod', type:'boolean', value:true, description: 'Wether to insta
 option('fmod_dir', type:'string', value:'lib/CortexCommand/', description: 'Where to install the fmod library relative to prefix directory.')
 option('install_data', type: 'boolean', value: true, description: 'Whether to install the data repo.')
 option('install_runner', type: 'boolean', value: true, description: 'Whether to install the runner script.')
+option('sane_warnings', type: 'boolean', value: true, description: 'Disable certain warnings, that are reasonably safe to ignore, though we should fix them at some point.')


### PR DESCRIPTION
Disable some Warnings that are not critical for now because they were polluting the logs:

 - `-Wno-deprecated-declarations` luabind related can be ignored entirely
 - `-Wno-sign-compare` safe for now though could technically lead to signedness bugs in places, seems to be mostly enum compares
 - `-Wno-non-virtual-dtor` technically critical for fixing memory leaks, but missing in virtually all classes
 - `-Wno-overloaded-virtual` complains on hidden technical [override](https://stackoverflow.com/questions/18515183/c-overloaded-virtual-function-warning-by-clang). not critical, but may need to be checked at some point
 - `-Wno-parentheses` code readbility
 - `-Wno-unused-function` in LuaAdapters*.cpp