### PR TITLE
BuyMenu Mecha Tab

### DIFF
--- a/Managers/PresetMan.cpp
+++ b/Managers/PresetMan.cpp
@@ -575,6 +575,47 @@ bool PresetMan::GetAllOfGroup(list<Entity *> &entityList, string group, string t
     return foundAny;
 }
 
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+bool PresetMan::GetAllOfGroups(std::list<Entity *> &entityList, const std::vector<std::string> &groups, const std::string &type, int whichModule) {
+	RTEAssert(!groups.empty(), "Looking for empty groups!");
+	bool foundAny = false;
+
+	if (whichModule < 0) {
+		for (DataModule *dataModule : m_pDataModules) {
+			foundAny = dataModule->GetAllOfGroups(entityList, groups, type) || foundAny;
+		}
+	} else {
+		RTEAssert(whichModule < m_pDataModules.size(), "Trying to get from an out of bounds DataModule ID!");
+		foundAny = m_pDataModules[whichModule]->GetAllOfGroups(entityList, groups, type);
+	}
+	return foundAny;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+bool PresetMan::GetAllNotOfGroups(std::list<Entity *> &entityList, const std::vector<std::string> &groups, const std::string &type, int whichModule) {
+	RTEAssert(!type.empty(), "Looking presets of type without specifying type in PresetMan::GetAllNotOfGroups");
+
+	if (groups.empty()) {
+		RTEAbort("Looking for empty groups in PresetMan::GetAllNotOfGroups");
+	} else if (std::find(groups.begin(), groups.end(), "All") != groups.end()) {
+		RTEAbort("Trying to exclude all groups while looking for presets in PresetMan::GetAllNotOfGroups");
+	}
+
+	bool foundAny = false;
+
+	if (whichModule < 0) {
+		for (DataModule *dataModule : m_pDataModules) {
+			foundAny = dataModule->GetAllNotOfGroups(entityList, groups, type) || foundAny;
+		}
+	} else {
+		RTEAssert(whichModule < m_pDataModules.size(), "Trying to get from an out of bounds DataModule ID!");
+		foundAny = m_pDataModules[whichModule]->GetAllNotOfGroups(entityList, groups, type);
+	}
+	return foundAny;
+}
+
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // Method:          GetRandomOfGroup

--- a/Managers/PresetMan.cpp
+++ b/Managers/PresetMan.cpp
@@ -501,7 +501,7 @@ bool PresetMan::GetAllOfType(list<Entity *> &entityList, string type, int whichM
     {
         // Send the list to each module
         for (int i = 0; i < m_pDataModules.size(); ++i)
-            foundAny = m_pDataModules[i]->GetAllOfType(entityList, type) || foundAny; 
+            foundAny = m_pDataModules[i]->GetAllOfType(entityList, type) || foundAny;
     }
     // Specific module
     else
@@ -730,7 +730,7 @@ Entity * PresetMan::GetRandomBuyableOfGroupFromTech(string group, string type, i
 				return (*itr);
 		}
 	}
-	else 
+	else
 	{
 		for (list<Entity *>::iterator itr = entityList.begin(); itr != entityList.end(); ++itr)
 		{
@@ -955,7 +955,7 @@ bool PresetMan::GetGroups(list<string> &groupList, int whichModule, string withT
 
             foundAny = !pGroupList->empty();
         }
-        // Get only modules that contain an entity of valid type 
+        // Get only modules that contain an entity of valid type
         else
             foundAny = m_pDataModules[whichModule]->GetGroupsWithType(groupList, withType) || foundAny;
     }
@@ -991,7 +991,7 @@ bool PresetMan::GetModuleSpaceGroups(list<string> &groupList, int whichModule, s
         else
         {
             for (int module = 0; module < (int)m_pDataModules.size(); ++module)
-                foundAny = GetGroups(groupList, module, withType) || foundAny;            
+                foundAny = GetGroups(groupList, module, withType) || foundAny;
         }
     }
     // Getting modulespace of specific module

--- a/Managers/PresetMan.cpp
+++ b/Managers/PresetMan.cpp
@@ -544,41 +544,10 @@ bool PresetMan::GetAllOfTypeInModuleSpace(std::list<Entity *> &entityList, std::
     return foundAny;
 }
 
-
-//////////////////////////////////////////////////////////////////////////////////////////
-// Method:          GetAllOfGroup
-//////////////////////////////////////////////////////////////////////////////////////////
-// Description:     Adds to a list all previously read in (defined) Entitys which are
-//                  associated with a specific group.
-
-bool PresetMan::GetAllOfGroup(list<Entity *> &entityList, string group, string type, int whichModule)
-{
-    RTEAssert(!group.empty(), "Looking for empty group!");
-
-    bool foundAny = false;
-
-    // All modules
-    if (whichModule < 0)
-    {
-        // Get from all modules
-        for (int i = 0; i < m_pDataModules.size(); ++i)
-            // Send the list to each module, let them add
-            foundAny = m_pDataModules[i]->GetAllOfGroup(entityList, group, type) || foundAny;
-    }
-    // Specific one
-    else
-    {
-        RTEAssert(whichModule < m_pDataModules.size(), "Trying to get from an out of bounds DataModule ID!");
-        foundAny = m_pDataModules[whichModule]->GetAllOfGroup(entityList, group, type);
-    }
-
-    return foundAny;
-}
-
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 bool PresetMan::GetAllOfGroups(std::list<Entity *> &entityList, const std::vector<std::string> &groups, const std::string &type, int whichModule) {
-	RTEAssert(!groups.empty(), "Looking for empty groups!");
+	RTEAssert(!groups.empty(), "Looking for empty groups in PresetMan::GetAllOfGroups!");
 	bool foundAny = false;
 
 	if (whichModule < 0) {
@@ -586,7 +555,7 @@ bool PresetMan::GetAllOfGroups(std::list<Entity *> &entityList, const std::vecto
 			foundAny = dataModule->GetAllOfGroups(entityList, groups, type) || foundAny;
 		}
 	} else {
-		RTEAssert(whichModule < m_pDataModules.size(), "Trying to get from an out of bounds DataModule ID!");
+		RTEAssert(whichModule < m_pDataModules.size(), "Trying to get from an out of bounds DataModule ID in PresetMan::GetAllOfGroups!");
 		foundAny = m_pDataModules[whichModule]->GetAllOfGroups(entityList, groups, type);
 	}
 	return foundAny;
@@ -595,12 +564,10 @@ bool PresetMan::GetAllOfGroups(std::list<Entity *> &entityList, const std::vecto
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 bool PresetMan::GetAllNotOfGroups(std::list<Entity *> &entityList, const std::vector<std::string> &groups, const std::string &type, int whichModule) {
-	RTEAssert(!type.empty(), "Looking presets of type without specifying type in PresetMan::GetAllNotOfGroups");
-
 	if (groups.empty()) {
-		RTEAbort("Looking for empty groups in PresetMan::GetAllNotOfGroups");
+		RTEAbort("Looking for empty groups in PresetMan::GetAllNotOfGroups!");
 	} else if (std::find(groups.begin(), groups.end(), "All") != groups.end()) {
-		RTEAbort("Trying to exclude all groups while looking for presets in PresetMan::GetAllNotOfGroups");
+		RTEAbort("Trying to exclude all groups while looking for presets in PresetMan::GetAllNotOfGroups!");
 	}
 
 	bool foundAny = false;
@@ -610,7 +577,7 @@ bool PresetMan::GetAllNotOfGroups(std::list<Entity *> &entityList, const std::ve
 			foundAny = dataModule->GetAllNotOfGroups(entityList, groups, type) || foundAny;
 		}
 	} else {
-		RTEAssert(whichModule < m_pDataModules.size(), "Trying to get from an out of bounds DataModule ID!");
+		RTEAssert(whichModule < m_pDataModules.size(), "Trying to get from an out of bounds DataModule ID in PresetMan::GetAllNotOfGroups!");
 		foundAny = m_pDataModules[whichModule]->GetAllNotOfGroups(entityList, groups, type);
 	}
 	return foundAny;
@@ -637,13 +604,13 @@ Entity * PresetMan::GetRandomOfGroup(string group, string type, int whichModule)
         // Get from all modules
         for (int i = 0; i < m_pDataModules.size(); ++i)
             // Send the list to each module, let them add
-            foundAny = m_pDataModules[i]->GetAllOfGroup(entityList, group, type) || foundAny;
+			foundAny = m_pDataModules[i]->GetAllOfGroups(entityList, { group }, type) || foundAny;
     }
     // Specific one
     else
     {
         RTEAssert(whichModule < m_pDataModules.size(), "Trying to get from an out of bounds DataModule ID!");
-        foundAny = m_pDataModules[whichModule]->GetAllOfGroup(entityList, group, type);
+		foundAny = m_pDataModules[whichModule]->GetAllOfGroups(entityList, { group }, type);
     }
 
     // Didn't find any of that group in those module(s)
@@ -683,11 +650,11 @@ Entity * PresetMan::GetRandomBuyableOfGroupFromTech(string group, string type, i
 	// All modules
 	if (whichModule < 0) {
 		for (DataModule *dataModule : m_pDataModules) {
-			if (dataModule->IsFaction()) { foundAny = dataModule->GetAllOfGroup(tempList, group, type) || foundAny; }
+			if (dataModule->IsFaction()) { foundAny = dataModule->GetAllOfGroups(tempList, { group }, type) || foundAny; }
 		}
 	} else {
 		RTEAssert(whichModule < m_pDataModules.size(), "Trying to get from an out of bounds DataModule ID!");
-		foundAny = m_pDataModules[whichModule]->GetAllOfGroup(tempList, group, type);
+		foundAny = m_pDataModules[whichModule]->GetAllOfGroups(tempList, { group }, type);
 	}
 
 	//Filter found entities, we need only buyables

--- a/Managers/PresetMan.h
+++ b/Managers/PresetMan.h
@@ -306,6 +306,26 @@ public:
 
     bool GetAllOfGroup(std::list<Entity *> &entityList, std::string group, std::string type = "All", int whichModule = -1);
 
+	/// <summary>
+	/// Adds to a list all previously read in (defined) Entities which are associated with several specific groups.
+	/// </summary>
+	/// <param name="entityList">Reference to a list which will get all matching Entities added to it. Ownership of the list or the Entities placed in it are NOT transferred!</param>
+	/// <param name="groups">The groups to look for. "All" will look in all.</param>
+	/// <param name="type">The name of the least common denominator type of the Entities you want. "All" will look at all types.</param>
+	/// <param name="whichModule">Whether to only get those of one specific DataModule (0-n), or all (-1).</param>
+	/// <returns>Whether any Entity:s were found and added to the list.</returns>
+	bool GetAllOfGroups(std::list<Entity *> &entityList, const std::vector<std::string> &groups, const std::string &type = "All", int whichModule = -1);
+
+	/// <summary>
+	/// Adds to a list all previously read in (defined) Entities which are not associated with several specific groups.
+	/// </summary>
+	/// <param name="entityList">Reference to a list which will get all matching Entities added to it. Ownership of the list or the Entities placed in it are NOT transferred!</param>
+	/// <param name="groups">The groups to exclude.</param>
+	/// <param name="type">The name of the least common denominator type of the Entities you want. "All" will look at all types.</param>
+	/// <param name="whichModule">Whether to only get those of one specific DataModule (0-n), or all (-1).</param>
+	/// <returns>Whether any Entity:s were found and added to the list.</returns>
+	bool GetAllNotOfGroups(std::list<Entity *> &entityList, const std::vector<std::string> &groups, const std::string &type = "All", int whichModule = -1);
+
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // Method:          GetRandomOfGroup

--- a/Managers/PresetMan.h
+++ b/Managers/PresetMan.h
@@ -291,20 +291,15 @@ public:
     bool GetAllOfTypeInModuleSpace(std::list<Entity *> &entityList, std::string type, int whichModuleSpace);
 
 
-//////////////////////////////////////////////////////////////////////////////////////////
-// Method:          GetAllOfGroup
-//////////////////////////////////////////////////////////////////////////////////////////
-// Description:     Adds to a list all previously read in (defined) Entitys which are
-//                  associated with a specific group.
-// Arguments:       Reference to a list which will get all matching Entity:s added to it.
-//                  Ownership of the list or the Entitys placed in it are NOT transferred!
-//                  The group to look for. "All" will look in all.
-//                  The name of the least common denominator type of the Entitys you want.
-//                  "All" will look at all types.
-//                  Whether to only get those of one specific DataModule (0-n), or all (-1).
-// Return value:    Whether any Entity:s were found and added to the list.
-
-    bool GetAllOfGroup(std::list<Entity *> &entityList, std::string group, std::string type = "All", int whichModule = -1);
+	/// <summary>
+	/// Adds to a list all previously read in (defined) Entities which are associated with a specific group.
+	/// </summary>
+	/// <param name="entityList">Reference to a list which will get all matching Entities added to it. Ownership of the list or the Entities placed in it are NOT transferred!</param>
+	/// <param name="group">The group to look for. "All" will look in all.</param>
+	/// <param name="type">The name of the least common denominator type of the Entities you want. "All" will look at all types.</param>
+	/// <param name="whichModule">Whether to only get those of one specific DataModule (0-n), or all (-1).</param>
+	/// <returns>Whether any Entities were found and added to the list.</returns>
+	bool GetAllOfGroup(std::list<Entity *> &entityList, const std::string &group, const std::string &type = "All", int whichModule = -1) { return GetAllOfGroups(entityList, { group }, type, whichModule); }
 
 	/// <summary>
 	/// Adds to a list all previously read in (defined) Entities which are associated with several specific groups.
@@ -313,8 +308,18 @@ public:
 	/// <param name="groups">The groups to look for. "All" will look in all.</param>
 	/// <param name="type">The name of the least common denominator type of the Entities you want. "All" will look at all types.</param>
 	/// <param name="whichModule">Whether to only get those of one specific DataModule (0-n), or all (-1).</param>
-	/// <returns>Whether any Entity:s were found and added to the list.</returns>
+	/// <returns>Whether any Entities were found and added to the list.</returns>
 	bool GetAllOfGroups(std::list<Entity *> &entityList, const std::vector<std::string> &groups, const std::string &type = "All", int whichModule = -1);
+
+	/// <summary>
+	/// Adds to a list all previously read in (defined) Entities which are not associated with a specific group.
+	/// </summary>
+	/// <param name="entityList">Reference to a list which will get all matching Entities added to it. Ownership of the list or the Entities placed in it are NOT transferred!</param>
+	/// <param name="group">The group to exclude.</param>
+	/// <param name="type">The name of the least common denominator type of the Entities you want. "All" will look at all types.</param>
+	/// <param name="whichModule">Whether to only get those of one specific DataModule (0-n), or all (-1).</param>
+	/// <returns>Whether any Entities were found and added to the list.</returns>
+	bool GetAllNotOfGroup(std::list<Entity *> &entityList, const std::string &group, const std::string &type = "All", int whichModule = -1) { return GetAllNotOfGroups(entityList, { group }, type, whichModule); }
 
 	/// <summary>
 	/// Adds to a list all previously read in (defined) Entities which are not associated with several specific groups.
@@ -323,7 +328,7 @@ public:
 	/// <param name="groups">The groups to exclude.</param>
 	/// <param name="type">The name of the least common denominator type of the Entities you want. "All" will look at all types.</param>
 	/// <param name="whichModule">Whether to only get those of one specific DataModule (0-n), or all (-1).</param>
-	/// <returns>Whether any Entity:s were found and added to the list.</returns>
+	/// <returns>Whether any Entities were found and added to the list.</returns>
 	bool GetAllNotOfGroups(std::list<Entity *> &entityList, const std::vector<std::string> &groups, const std::string &type = "All", int whichModule = -1);
 
 

--- a/Menus/BuyMenuGUI.cpp
+++ b/Menus/BuyMenuGUI.cpp
@@ -201,6 +201,7 @@ int BuyMenuGUI::Create(Controller *pController)
 
     m_pCategoryTabs[CRAFT] = dynamic_cast<GUITab *>(m_pGUIController->GetControl("CraftTab"));
     m_pCategoryTabs[BODIES] = dynamic_cast<GUITab *>(m_pGUIController->GetControl("BodiesTab"));
+	m_pCategoryTabs[MECHA] = dynamic_cast<GUITab *>(m_pGUIController->GetControl("MechaTab"));
     m_pCategoryTabs[TOOLS] = dynamic_cast<GUITab *>(m_pGUIController->GetControl("ToolsTab"));
     m_pCategoryTabs[GUNS] = dynamic_cast<GUITab *>(m_pGUIController->GetControl("GunsTab"));
     m_pCategoryTabs[BOMBS] = dynamic_cast<GUITab *>(m_pGUIController->GetControl("BombsTab"));
@@ -828,14 +829,15 @@ void BuyMenuGUI::EnableEquipmentSelection(bool enabled) {
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 void BuyMenuGUI::RefreshTabDisabledStates() {
-    bool smartBuyMenuNavigationDisabled = !g_SettingsMan.SmartBuyMenuNavigationEnabled();
-    m_pCategoryTabs[CRAFT]->SetEnabled(smartBuyMenuNavigationDisabled || !m_SelectingEquipment);
-    m_pCategoryTabs[BODIES]->SetEnabled(smartBuyMenuNavigationDisabled || !m_SelectingEquipment);
-    m_pCategoryTabs[TOOLS]->SetEnabled(smartBuyMenuNavigationDisabled || m_SelectingEquipment);
-    m_pCategoryTabs[GUNS]->SetEnabled(smartBuyMenuNavigationDisabled || m_SelectingEquipment);
-    m_pCategoryTabs[BOMBS]->SetEnabled(smartBuyMenuNavigationDisabled || m_SelectingEquipment);
-    m_pCategoryTabs[SHIELDS]->SetEnabled(smartBuyMenuNavigationDisabled || m_SelectingEquipment);
-    m_pCategoryTabs[SETS]->SetEnabled(smartBuyMenuNavigationDisabled || !m_SelectingEquipment);
+	bool smartBuyMenuNavigationDisabled = !g_SettingsMan.SmartBuyMenuNavigationEnabled();
+	m_pCategoryTabs[CRAFT]->SetEnabled(smartBuyMenuNavigationDisabled || !m_SelectingEquipment);
+	m_pCategoryTabs[BODIES]->SetEnabled(smartBuyMenuNavigationDisabled || !m_SelectingEquipment);
+	m_pCategoryTabs[MECHA]->SetEnabled(smartBuyMenuNavigationDisabled || !m_SelectingEquipment);
+	m_pCategoryTabs[TOOLS]->SetEnabled(smartBuyMenuNavigationDisabled || m_SelectingEquipment);
+	m_pCategoryTabs[GUNS]->SetEnabled(smartBuyMenuNavigationDisabled || m_SelectingEquipment);
+	m_pCategoryTabs[BOMBS]->SetEnabled(smartBuyMenuNavigationDisabled || m_SelectingEquipment);
+	m_pCategoryTabs[SHIELDS]->SetEnabled(smartBuyMenuNavigationDisabled || m_SelectingEquipment);
+	m_pCategoryTabs[SETS]->SetEnabled(smartBuyMenuNavigationDisabled || !m_SelectingEquipment);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1995,32 +1997,23 @@ void BuyMenuGUI::CategoryChange(bool focusOnCategoryTabs)
     // The vector of lists which will be filled with catalog objects, grouped by which data module they were read from
     vector<list<Entity *> > catalogList;
 
-    if (m_MenuCategory == CRAFT)
-    {
-        AddObjectsToItemList(catalogList, "ACRocket");
-        AddObjectsToItemList(catalogList, "ACDropShip");
-    }
-    else if (m_MenuCategory == BODIES)
-    {
-        AddObjectsToItemList(catalogList, "AHuman");
-        AddObjectsToItemList(catalogList, "ACrab");
-    }
-    else if (m_MenuCategory == TOOLS)
-    {
+	if (m_MenuCategory == CRAFT) {
+		AddObjectsToItemList(catalogList, "ACRocket");
+		AddObjectsToItemList(catalogList, "ACDropShip");
+	} else if (m_MenuCategory == BODIES) {
+		AddObjectsToItemList(catalogList, "AHuman");
+		AddObjectsToItemList(catalogList, "ACrab");
+	} else if (m_MenuCategory == MECHA) {
+
+	} else if (m_MenuCategory == TOOLS) {
 		AddObjectsToItemList(catalogList, "HeldDevice", "Tools");
-    }
-    else if (m_MenuCategory == GUNS)
-    {
-        AddObjectsToItemList(catalogList, "HDFirearm", "Weapons");
-    }
-    else if (m_MenuCategory == BOMBS)
-    {
-        AddObjectsToItemList(catalogList, "ThrownDevice", "Bombs");
-    }
-    else if (m_MenuCategory == SHIELDS)
-    {
-        AddObjectsToItemList(catalogList, "HeldDevice", "Shields");
-    }
+	} else if (m_MenuCategory == GUNS) {
+		AddObjectsToItemList(catalogList, "HDFirearm", "Weapons");
+	} else if (m_MenuCategory == BOMBS) {
+		AddObjectsToItemList(catalogList, "ThrownDevice", "Bombs");
+	} else if (m_MenuCategory == SHIELDS) {
+		AddObjectsToItemList(catalogList, "HeldDevice", "Shields");
+	}
 
     SceneObject *pSObject = 0;
     const DataModule *pModule = 0;

--- a/Menus/BuyMenuGUI.cpp
+++ b/Menus/BuyMenuGUI.cpp
@@ -1995,24 +1995,26 @@ void BuyMenuGUI::CategoryChange(bool focusOnCategoryTabs)
     }
 
     // The vector of lists which will be filled with catalog objects, grouped by which data module they were read from
-    vector<list<Entity *> > catalogList;
+    std::vector<std::list<Entity *>> catalogList;
+	std::vector<std::string> mechaCategoryGroups = { "Actors - Mecha", "Actors - Turrets" };
 
 	if (m_MenuCategory == CRAFT) {
 		AddObjectsToItemList(catalogList, "ACRocket");
 		AddObjectsToItemList(catalogList, "ACDropShip");
 	} else if (m_MenuCategory == BODIES) {
-		AddObjectsToItemList(catalogList, "AHuman");
-		AddObjectsToItemList(catalogList, "ACrab");
+		AddObjectsToItemList(catalogList, "AHuman", mechaCategoryGroups, true);
+		AddObjectsToItemList(catalogList, "ACrab", mechaCategoryGroups, true);
 	} else if (m_MenuCategory == MECHA) {
-
+		AddObjectsToItemList(catalogList, "AHuman", mechaCategoryGroups, false);
+		AddObjectsToItemList(catalogList, "ACrab", mechaCategoryGroups, false);
 	} else if (m_MenuCategory == TOOLS) {
-		AddObjectsToItemList(catalogList, "HeldDevice", "Tools");
+		AddObjectsToItemList(catalogList, "HeldDevice", { "Tools" });
 	} else if (m_MenuCategory == GUNS) {
-		AddObjectsToItemList(catalogList, "HDFirearm", "Weapons");
+		AddObjectsToItemList(catalogList, "HDFirearm", { "Weapons" });
 	} else if (m_MenuCategory == BOMBS) {
-		AddObjectsToItemList(catalogList, "ThrownDevice", "Bombs");
+		AddObjectsToItemList(catalogList, "ThrownDevice", { "Bombs" });
 	} else if (m_MenuCategory == SHIELDS) {
-		AddObjectsToItemList(catalogList, "HeldDevice", "Shields");
+		AddObjectsToItemList(catalogList, "HeldDevice", { "Shields" });
 	}
 
     SceneObject *pSObject = 0;

--- a/Menus/BuyMenuGUI.cpp
+++ b/Menus/BuyMenuGUI.cpp
@@ -2220,45 +2220,22 @@ bool BuyMenuGUI::DeployLoadout(int index)
     return true;
 }
 
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-//////////////////////////////////////////////////////////////////////////////////////////
-// Virtual Method:  AddObjectsToItemList
-//////////////////////////////////////////////////////////////////////////////////////////
-// Description:     Adds all objects of a specific type already defined in PresetMan
-//                  to the current shop/item list. They will be grouped into the different
-//                  data modules they were read from.
-
-void BuyMenuGUI::AddObjectsToItemList(vector<list<Entity *> > &moduleList, string type, string group)
-{
-
-	if (g_SettingsMan.ShowForeignItems() || m_NativeTechModule <= 0)
-	{
-		// Make as many datamodule entries as necessary in the vector
-		while (moduleList.size() < g_PresetMan.GetTotalModuleCount())
-			moduleList.push_back(list<Entity *>());
-
-		// Go through all the data modules, gathering the objects that match the criteria in each one
-		for (int moduleID = 0; moduleID < g_PresetMan.GetTotalModuleCount(); ++moduleID)
-		{
-			if (group.empty() || group == "All")
+void BuyMenuGUI::AddObjectsToItemList(std::vector<std::list<Entity *>> &moduleList, const std::string &type, const std::vector<std::string> &groups, bool excludeGroups) {
+	while (moduleList.size() < g_PresetMan.GetTotalModuleCount()) {
+		moduleList.emplace_back();
+	}
+	for (int moduleID = 0; moduleID < g_PresetMan.GetTotalModuleCount(); ++moduleID) {
+		if ((g_SettingsMan.ShowForeignItems() || m_NativeTechModule <= 0) || (moduleID == 0 || moduleID == m_NativeTechModule || g_PresetMan.GetDataModule(moduleID)->IsMerchant())) {
+			if (groups.empty() || std::find(groups.begin(), groups.end(), "All") != groups.end()) {
 				g_PresetMan.GetAllOfType(moduleList[moduleID], type, moduleID);
-			else
-				g_PresetMan.GetAllOfGroup(moduleList[moduleID], group, type, moduleID);
-		}
-	} else {
-		// Make as many datamodule entries as necessary in the vector
-		while (moduleList.size() < g_PresetMan.GetTotalModuleCount())
-			moduleList.push_back(list<Entity *>());
-
-		// Go through all the data modules, gathering the objects that match the criteria in each one
-		for (int moduleID = 0; moduleID < g_PresetMan.GetTotalModuleCount(); ++moduleID)
-		{
-			if (moduleID == 0 || moduleID == m_NativeTechModule || g_PresetMan.GetDataModule(moduleID)->IsMerchant())
-			{
-				if (group.empty() || group == "All")
-					g_PresetMan.GetAllOfType(moduleList[moduleID], type, moduleID);
-				else
-					g_PresetMan.GetAllOfGroup(moduleList[moduleID], group, type, moduleID);
+			} else {
+				if (excludeGroups) {
+					g_PresetMan.GetAllNotOfGroups(moduleList[moduleID], groups, type, moduleID);
+				} else {
+					g_PresetMan.GetAllOfGroups(moduleList[moduleID], groups, type, moduleID);
+				}
 			}
 		}
 	}

--- a/Menus/BuyMenuGUI.h
+++ b/Menus/BuyMenuGUI.h
@@ -617,18 +617,14 @@ protected:
     bool DeployLoadout(int index);
 
 
-//////////////////////////////////////////////////////////////////////////////////////////
-// Method:          AddObjectsToItemList
-//////////////////////////////////////////////////////////////////////////////////////////
-// Description:     Adds all objects of a specific type already defined in PresetMan
-//                  to the current shop/item list. They will be grouped into the different
-//                  data modules they were read from.
-// Arguments:       Reference to the data module vector of entity lists to add the items to.
-//                  The name of the class to add all objects of. "" or "All" looks for all.
-//                  The name of the group to add all objects of. "" or "All" looks for all.
-// Return value:    None.
-
-    void AddObjectsToItemList(std::vector<std::list<Entity *> > &moduleList, std::string type = "", std::string group = "");
+	/// <summary>
+	/// Adds all objects of a specific type already defined in PresetMan to the current shop/item list. They will be grouped into the different data modules they were read from.
+	/// </summary>
+	/// <param name="moduleList">Reference to the data module vector of entity lists to add the items to.</param>
+	/// <param name="type">The name of the class to add all objects of. "" or "All" looks for all.</param>
+	/// <param name="groups">The name of the groups to add all objects of. An empty vector or "All" looks for all.</param>
+	/// <param name="excludeGroups">Whether the specified groups should be excluded, meaning all objects NOT associated with the groups will be added.</param>
+	void AddObjectsToItemList(std::vector<std::list<Entity *>> &moduleList, const std::string &type = "", const std::vector<std::string> &groups = {}, bool excludeGroups = false);
 
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/Menus/BuyMenuGUI.h
+++ b/Menus/BuyMenuGUI.h
@@ -706,6 +706,7 @@ protected:
     {
         CRAFT = 0,
         BODIES,
+		MECHA,
         TOOLS,
         GUNS,
         BOMBS,

--- a/System/DataModule.cpp
+++ b/System/DataModule.cpp
@@ -215,13 +215,11 @@ namespace RTE {
 		if (exactType.empty() || instance == "None" || instance.empty()) {
 			return nullptr;
 		}
-
-		std::map<std::string, std::list<std::pair<std::string, Entity *>>>::iterator classItr = m_TypeMap.find(exactType);
-		if (classItr != m_TypeMap.end()) {
+		if (auto classItr = m_TypeMap.find(exactType); classItr != m_TypeMap.end()) {
 			// Find an instance of that EXACT type and name; derived types are not matched
-			for (const std::pair<std::string, Entity *> &classItrEntry : classItr->second) {
-				if (classItrEntry.first == instance && classItrEntry.second->GetClassName() == exactType) {
-					return classItrEntry.second;
+			for (const auto &[instanceName, entity] : classItr->second) {
+				if (instanceName == instance && entity->GetClassName() == exactType) {
+					return entity;
 				}
 			}
 		}
@@ -237,9 +235,8 @@ namespace RTE {
 			return false;
 		}
 		bool entityAdded = false;
-		Entity *existingEntity = GetEntityIfExactType(entityToAdd->GetClassName(), entityToAdd->GetPresetName());
 
-		if (existingEntity) {
+		if (Entity *existingEntity = GetEntityIfExactType(entityToAdd->GetClassName(), entityToAdd->GetPresetName())) {
 			// If we're commanded to overwrite any collisions, then do so by cloning over the existing instance in the list
 			// This way we're not invalidating any instance references that would have been taken out and held by clients
 			if (overwriteSame) {
@@ -293,12 +290,11 @@ namespace RTE {
 				// But I suppose no actual finding is done. Investigate this and see where it's called, maybe this should be changed
 			}
 		} else {
-			std::map<std::string, std::list<std::pair<std::string, Entity *>>>::iterator classItr = m_TypeMap.find(withType);
-			if (classItr != m_TypeMap.end()) {
+			if (auto classItr = m_TypeMap.find(withType); classItr != m_TypeMap.end()) {
 				const std::list<std::string> *groupListPtr = nullptr;
 				// Go through all the entities of that type, adding the groups they belong to
-				for (const std::pair<std::string, Entity *> &instance : classItr->second) {
-					groupListPtr = instance.second->GetGroupList();
+				for (const auto &[instanceName, entity] : classItr->second) {
+					groupListPtr = entity->GetGroupList();
 
 					for (const std::string &groupListEntry : *groupListPtr) {
 						groupList.push_back(groupListEntry); // Get the grouped entities, without transferring ownership
@@ -361,12 +357,11 @@ namespace RTE {
 			return false;
 		}
 
-		std::map<std::string, std::list<std::pair<std::string, Entity *>>>::iterator classItr = m_TypeMap.find(type);
-		if (classItr != m_TypeMap.end()) {
+		if (auto classItr = m_TypeMap.find(type);  classItr != m_TypeMap.end()) {
 			RTEAssert(!classItr->second.empty(), "DataModule has class entry without instances in its map!?");
 
-			for (const std::pair<std::string, Entity *> &instance : classItr->second) {
-				entityList.push_back(instance.second); // Get the entities, without transferring ownership
+			for (const auto &[instanceName, entity] : classItr->second) {
+				entityList.push_back(entity); // Get the entities, without transferring ownership
 			}
 			return true;
 		}
@@ -424,13 +419,11 @@ namespace RTE {
 		if (exactType.empty() || presetName == "None" || presetName.empty()) {
 			return nullptr;
 		}
-
-		std::map<std::string, std::list<std::pair<std::string, Entity *>>>::iterator classItr = m_TypeMap.find(exactType);
-		if (classItr != m_TypeMap.end()) {
+		if (auto classItr = m_TypeMap.find(exactType); classItr != m_TypeMap.end()) {
 			// Find an instance of that EXACT type and name; derived types are not matched
-			for (const std::pair<std::string, Entity *> &instance : classItr->second) {
-				if (instance.first == presetName && instance.second->GetClassName() == exactType) {
-					return instance.second;
+			for (const auto &[instanceName, entity] : classItr->second) {
+				if (instanceName == presetName && entity->GetClassName() == exactType) {
+					return entity;
 				}
 			}
 		}
@@ -446,7 +439,7 @@ namespace RTE {
 
 		// Walk up the class hierarchy till we reach the top, adding an entry of the passed in entity into each typelist as we go along
 		for (const Entity::ClassInfo *pClass = &(entityToAdd->GetClass()); pClass != nullptr; pClass = pClass->GetParent()) {
-			std::map<std::string, std::list<std::pair<std::string, Entity *>>>::iterator classItr = m_TypeMap.find(pClass->GetName());
+			auto classItr = m_TypeMap.find(pClass->GetName());
 
 			// No instances of this entity have been added yet so add a class category for it
 			if (classItr == m_TypeMap.end()) {

--- a/System/DataModule.cpp
+++ b/System/DataModule.cpp
@@ -317,27 +317,20 @@ namespace RTE {
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 
-	bool DataModule::GetAllOfOrNotOfGroups(std::list<Entity *> &entityList, const std::string &type, const std::variant<const std::string, const std::vector<std::string>> &groups, bool excludeGroups) {
-		std::vector<std::string> groupsList;
-		if (const std::string *group = std::get_if<const std::string>(&groups)) {
-			if (!group->empty()) { groupsList.emplace_back(*group); }
-		} else {
-			groupsList = std::get<const std::vector<std::string>>(groups);
-		}
-		if (groupsList.empty()) {
+	bool DataModule::GetAllOfOrNotOfGroups(std::list<Entity *> &entityList, const std::string &type, const std::vector<std::string> &groups, bool excludeGroups) {
+		if (groups.empty()) {
 			return false;
 		}
-
 		bool foundAny = false;
 
 		// Find either the Entity typelist that contains all entities in this DataModule, or the specific class' typelist (which will get all derived classes too).
-		if (std::map<std::string, std::list<std::pair<std::string, Entity *>>>::iterator classItr = m_TypeMap.find((type.empty() || type == "All") ? "Entity" : type); classItr != m_TypeMap.end()) {
+		if (auto classItr = m_TypeMap.find((type.empty() || type == "All") ? "Entity" : type); classItr != m_TypeMap.end()) {
 			RTEAssert(!classItr->second.empty(), "DataModule has class entry without instances in its map!?");
 
 			for (const auto &[instanceName, entity] : classItr->second) {
 				if (excludeGroups) {
 					bool excludeEntity = false;
-					for (const std::string &group : groupsList) {
+					for (const std::string &group : groups) {
 						if (entity->IsInGroup(group)) {
 							excludeEntity = true;
 							break;
@@ -348,7 +341,7 @@ namespace RTE {
 						foundAny = true;
 					}
 				} else {
-					for (const std::string &group : groupsList) {
+					for (const std::string &group : groups) {
 						if (entity->IsInGroup(group)) {
 							entityList.emplace_back(entity);
 							foundAny = true;

--- a/System/DataModule.h
+++ b/System/DataModule.h
@@ -209,15 +209,6 @@ namespace RTE {
 		bool GetGroupsWithType(std::list<std::string> &groupList, const std::string &withType);
 
 		/// <summary>
-		/// Adds to a list all previously read in (defined) Entities which are associated with a specific group.
-		/// </summary>
-		/// <param name="entityList">Reference to a list which will get all matching Entities added to it. Ownership of the list or the Entities placed in it are NOT transferred!</param>
-		/// <param name="group">The group to look for.</param>
-		/// <param name="type">The name of the least common denominator type of the Entities you want. "All" will look at all types.</param>
-		/// <returns>Whether any Entities were found and added to the list.</returns>
-		bool GetAllOfGroup(std::list<Entity *> &entityList, const std::string &group, const std::string &type) { return GetAllOfOrNotOfGroups(entityList, type, group, false); }
-
-		/// <summary>
 		/// Adds to a list all previously read in (defined) Entities which are associated with several specific groups.
 		/// </summary>
 		/// <param name="entityList">Reference to a list which will get all matching Entities added to it. Ownership of the list or the Entities placed in it are NOT transferred!</param>
@@ -225,15 +216,6 @@ namespace RTE {
 		/// <param name="type">The name of the least common denominator type of the Entities you want. "All" will look at all types.</param>
 		/// <returns>Whether any Entities were found and added to the list.</returns>
 		bool GetAllOfGroups(std::list<Entity *> &entityList, const std::vector<std::string> &groups, const std::string &type) { return GetAllOfOrNotOfGroups(entityList, type, groups, false); }
-
-		/// <summary>
-		/// Adds to a list all previously read in (defined) Entities which are not associated with a specific group.
-		/// </summary>
-		/// <param name="entityList">Reference to a list which will get all matching Entities added to it. Ownership of the list or the Entities placed in it are NOT transferred!</param>
-		/// <param name="group">The group to exclude.</param>
-		/// <param name="type">The name of the least common denominator type of the Entities you want. "All" will look at all types.</param>
-		/// <returns>Whether any Entities were found and added to the list.</returns>
-		bool GetAllNotOfGroup(std::list<Entity *> &entityList, const std::string &group, const std::string &type) { return GetAllOfOrNotOfGroups(entityList, type, group, true); }
 
 		/// <summary>
 		/// Adds to a list all previously read in (defined) Entities which are not associated with several specific groups.
@@ -365,10 +347,10 @@ namespace RTE {
 		/// </summary>
 		/// <param name="entityList">Reference to a list which will get all matching Entities added to it. Ownership of the list or the Entities placed in it are NOT transferred!</param>
 		/// <param name="type">The name of the least common denominator type of the Entities you want. "All" will look at all types.</param>
-		/// <param name="groups">The group or groups to look for.</param>
+		/// <param name="groups">The groups to look for.</param>
 		/// <param name="excludeGroups">Whether Entities belonging to the specified group or groups should be excluded.</param>
 		/// <returns>Whether any Entities were found and added to the list.</returns>
-		bool GetAllOfOrNotOfGroups(std::list<Entity *> &entityList, const std::string &type, const std::variant<const std::string, const std::vector<std::string>> &groups, bool excludeGroups);
+		bool GetAllOfOrNotOfGroups(std::list<Entity *> &entityList, const std::string &type, const std::vector<std::string> &groups, bool excludeGroups);
 
 		/// <summary>
 		/// Checks if the type map has an instance added of a specific name and exact type.

--- a/System/DataModule.h
+++ b/System/DataModule.h
@@ -326,7 +326,7 @@ namespace RTE {
 		/// There can be multiple entries of the same instance name in any of the type sub-maps, but only ONE whose exact class is that of the type-list!
 		/// The Entity instances are NOT owned by this map.
 		/// </summary>
-		std::map<std::string, std::list<std::pair<std::string, Entity *>>> m_TypeMap;
+		std::unordered_map<std::string, std::list<std::pair<std::string, Entity *>>> m_TypeMap;
 
 	private:
 

--- a/System/DataModule.h
+++ b/System/DataModule.h
@@ -211,11 +211,38 @@ namespace RTE {
 		/// <summary>
 		/// Adds to a list all previously read in (defined) Entities which are associated with a specific group.
 		/// </summary>
-		/// <param name="objectList">Reference to a list which will get all matching Entities added to it. Ownership of the list or the Entities placed in it are NOT transferred!</param>
+		/// <param name="entityList">Reference to a list which will get all matching Entities added to it. Ownership of the list or the Entities placed in it are NOT transferred!</param>
 		/// <param name="group">The group to look for.</param>
 		/// <param name="type">The name of the least common denominator type of the Entities you want. "All" will look at all types.</param>
 		/// <returns>Whether any Entities were found and added to the list.</returns>
-		bool GetAllOfGroup(std::list<Entity *> &objectList, const std::string &group, const std::string &type);
+		bool GetAllOfGroup(std::list<Entity *> &entityList, const std::string &group, const std::string &type) { return GetAllOfOrNotOfGroups(entityList, type, group, false); }
+
+		/// <summary>
+		/// Adds to a list all previously read in (defined) Entities which are associated with several specific groups.
+		/// </summary>
+		/// <param name="entityList">Reference to a list which will get all matching Entities added to it. Ownership of the list or the Entities placed in it are NOT transferred!</param>
+		/// <param name="groups">A list of groups to look for.</param>
+		/// <param name="type">The name of the least common denominator type of the Entities you want. "All" will look at all types.</param>
+		/// <returns>Whether any Entities were found and added to the list.</returns>
+		bool GetAllOfGroups(std::list<Entity *> &entityList, const std::vector<std::string> &groups, const std::string &type) { return GetAllOfOrNotOfGroups(entityList, type, groups, false); }
+
+		/// <summary>
+		/// Adds to a list all previously read in (defined) Entities which are not associated with a specific group.
+		/// </summary>
+		/// <param name="entityList">Reference to a list which will get all matching Entities added to it. Ownership of the list or the Entities placed in it are NOT transferred!</param>
+		/// <param name="group">The group to exclude.</param>
+		/// <param name="type">The name of the least common denominator type of the Entities you want. "All" will look at all types.</param>
+		/// <returns>Whether any Entities were found and added to the list.</returns>
+		bool GetAllNotOfGroup(std::list<Entity *> &entityList, const std::string &group, const std::string &type) { return GetAllOfOrNotOfGroups(entityList, type, group, true); }
+
+		/// <summary>
+		/// Adds to a list all previously read in (defined) Entities which are not associated with several specific groups.
+		/// </summary>
+		/// <param name="entityList">Reference to a list which will get all matching Entities added to it. Ownership of the list or the Entities placed in it are NOT transferred!</param>
+		/// <param name="group">A list of groups to exclude.</param>
+		/// <param name="type">The name of the least common denominator type of the Entities you want. "All" will look at all types.</param>
+		/// <returns>Whether any Entities were found and added to the list.</returns>
+		bool GetAllNotOfGroups(std::list<Entity *> &entityList, const std::vector<std::string> &groups, const std::string &type) { return GetAllOfOrNotOfGroups(entityList, type, groups, true); }
 
 		/// <summary>
 		/// Adds to a list all previously read in (defined) Entities, by inexact type.
@@ -333,6 +360,16 @@ namespace RTE {
 #pragma endregion
 
 #pragma region Entity Mapping
+		/// <summary>
+		/// Shared method for filling a list with all previously read in (defined) Entities which are or are not associated with a specific group or groups.
+		/// </summary>
+		/// <param name="entityList">Reference to a list which will get all matching Entities added to it. Ownership of the list or the Entities placed in it are NOT transferred!</param>
+		/// <param name="type">The name of the least common denominator type of the Entities you want. "All" will look at all types.</param>
+		/// <param name="groups">The group or groups to look for.</param>
+		/// <param name="excludeGroups">Whether Entities belonging to the specified group or groups should be excluded.</param>
+		/// <returns>Whether any Entities were found and added to the list.</returns>
+		bool GetAllOfOrNotOfGroups(std::list<Entity *> &entityList, const std::string &type, const std::variant<const std::string, const std::vector<std::string>> &groups, bool excludeGroups);
+
 		/// <summary>
 		/// Checks if the type map has an instance added of a specific name and exact type.
 		/// Does not check if any parent types with that name has been added. If found, that instance is returned, otherwise 0.

--- a/System/StandardIncludes.h
+++ b/System/StandardIncludes.h
@@ -77,7 +77,6 @@
 #include <random>
 #include <array>
 #include <filesystem>
-#include <variant>
 
 // TODO: Get rid of these once alias qualifiers are added.
 using std::string;

--- a/System/StandardIncludes.h
+++ b/System/StandardIncludes.h
@@ -77,6 +77,7 @@
 #include <random>
 #include <array>
 #include <filesystem>
+#include <variant>
 
 // TODO: Get rid of these once alias qualifiers are added.
 using std::string;


### PR DESCRIPTION
Add new `Mecha` tab to the buy menu that will contain all actors that are part of the `Actors - Mecha` and/or `Actors - Turrets` groups.
Actors belonging to these groups will no longer be displayed in the `Bodies` tab.
