### PR TITLE
fix: stop out of bounds `PieSlice` directions crashing with no error

### DIFF
--- a/Entities/PieSlice.cpp
+++ b/Entities/PieSlice.cpp
@@ -81,7 +81,11 @@ namespace RTE {
 				m_Direction = c_DirectionNameToDirectionsMap.find(directionString)->second;
 			} else {
 				try {
-					m_Direction = static_cast<Directions>(std::stoi(directionString));
+					int direction = std::stoi(directionString);
+					if (direction < Directions::None || direction > Directions::Any) {
+						reader.ReportError("Direction " + directionString + " is invalid (Out of Bounds).");
+					}
+					m_Direction = static_cast<Directions>(direction);
 				} catch (const std::invalid_argument &) {
 					reader.ReportError("Direction " + directionString + " is invalid.");
 				}


### PR DESCRIPTION
Add a range check to ensure that a PieSlice's specified direction index maps to the available Directions enum members. Report reader error if out of bounds.

See #478 for full details.