### PR TITLE
Bug/500 fix meson builds on macos

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,14 @@ If you want to change the buildtype afterwards, you can use `meson configure --b
 
    `cd $DATA_REPOSITORY; ln -s ../Cortex-Command-Community-Project-Source/build/CortexCommand . `
 
-2. Copy all `libfmod` files from `external/lib/linux/x86_64` into the **Data Repository**.
+2. 
+   - #### Linux:
+      Copy (link) all `libfmod` files from `external/lib/linux/x86_64` into the **Data Repository**.
 
-   `cd $DATA_REPOSITORY; ln -s ../Cortex-Command-Community-Project-Source/external/lib/linux/x86_64/libfmod.so* .`
+      `cd $DATA_REPOSITORY; ln -s ../Cortex-Command-Community-Project-Source/external/lib/linux/x86_64/libfmod.so* .`
+
+   - #### macOS
+      macOS builds automatically resolve the relative path from `build/` where the executable exists to `external/lib/macos/`. If the executable is being launched via the symlink from Step 1 then this step is not required. 
 
 4. Run `./CortexCommand` or `./CortexCommand_debug` in the **Data Repository**.
 

--- a/meson.build
+++ b/meson.build
@@ -34,6 +34,11 @@ if compiler.get_argument_syntax()== 'gcc' # used for gcc compatible compilers
   message('gcc detected')
 
   build_rpath = '$ORIGIN:$ORIGIN/../external/lib/linux/x86_64' # Set RUNPATH so that CCCP can find libfmod.so without needing to set LD_LIBRARY_PATH
+  
+  if host_machine.system()=='darwin'
+  build_rpath = '@executable_path/../external/lib/macos' # Add a new R_PATH CCCP can find libfmod.dylib on Darwin TODO: Confirm and validate this.
+	endif
+
   #suffix = 'x86_64'
 	if host_machine.system()=='linux'
   link_args += ['-Wl,--enable-new-dtags'] # Set RUNPATH instead of RPATH


### PR DESCRIPTION
Fixes macOS builds failing to load fmod at runtime. 

Detailed discussion in discord from here on (I cannot be arsed typing this all again): https://discord.com/channels/746526891841945640/746526892173033498/1117467587119423611

 Closes #500 

Makes shoddy changes to the `README.md` and `meson.build` files,  but achieves the required results. Wording/technical improvements much appreciated. 

#### We now no longer need to symlink/copy the fmod library on mac, may be able to replicate this on Linux by copying these changes. 
