### PR TITLE
Camera Wrapping Fix

### DIFF
--- a/Activities/GameActivity.cpp
+++ b/Activities/GameActivity.cpp
@@ -1480,7 +1480,8 @@ void GameActivity::Update()
                 m_PlayerController[player].RelativeCursorMovement(m_ObservationTarget[player], 1.2f);
             }
             // Set the view to the observation position
-            g_CameraMan.SetScrollTarget(m_ObservationTarget[player], 0.1, g_SceneMan.ForceBounds(m_ObservationTarget[player]), ScreenOfPlayer(player));
+            g_SceneMan.ForceBounds(m_ObservationTarget[player]);
+            g_CameraMan.SetScrollTarget(m_ObservationTarget[player], 0.1, ScreenOfPlayer(player));
         }
 
         ///////////////////////////////////////////////////
@@ -1543,8 +1544,8 @@ void GameActivity::Update()
             }
 
             // Set the view to the cursor pos
-            bool wrapped = g_SceneMan.ForceBounds(m_ActorCursor[player]);
-            g_CameraMan.SetScrollTarget(m_ActorCursor[player], 0.1, wrapped, ScreenOfPlayer(player));
+            g_SceneMan.ForceBounds(m_ActorCursor[player]);
+            g_CameraMan.SetScrollTarget(m_ActorCursor[player], 0.1, ScreenOfPlayer(player));
 
 			if (m_pLastMarkedActor[player]) {
 				if (!g_MovableMan.ValidMO(m_pLastMarkedActor[player])) {
@@ -1580,8 +1581,8 @@ void GameActivity::Update()
 			}
 
             // Set the view to the cursor pos
-            bool wrapped = g_SceneMan.ForceBounds(m_ActorCursor[player]);
-            g_CameraMan.SetScrollTarget(m_ActorCursor[player], 0.1, wrapped, ScreenOfPlayer(player));
+            g_SceneMan.ForceBounds(m_ActorCursor[player]);
+            g_CameraMan.SetScrollTarget(m_ActorCursor[player], 0.1, ScreenOfPlayer(player));
 
             // Draw the actor's waypoints
             m_ControlledActor[player]->DrawWaypoints(true);
@@ -1658,8 +1659,8 @@ void GameActivity::Update()
 
             // Set the view to the actor pos
 			Vector scrollPos = Vector(m_ControlledActor[player]->GetPos());
-            wrapped = g_SceneMan.ForceBounds(scrollPos);
-            g_CameraMan.SetScrollTarget(scrollPos, 0.1, wrapped, ScreenOfPlayer(player));
+            g_SceneMan.ForceBounds(scrollPos);
+            g_CameraMan.SetScrollTarget(scrollPos, 0.1, ScreenOfPlayer(player));
 
             // Disable the actor's controller
             m_ControlledActor[player]->GetController()->SetDisabled(true);
@@ -1834,7 +1835,7 @@ void GameActivity::Update()
 				m_LandingZone[player].m_Y -= lzOffsetY;
 			}
 
-            bool wrapped = g_SceneMan.ForceBounds(m_LandingZone[player]);
+            g_SceneMan.ForceBounds(m_LandingZone[player]);
 
             // Interpolate the LZ altitude to the height of the highest terrain point at the player-chosen X
             float prevHeight = m_LandingZone[player].m_Y;
@@ -1843,7 +1844,7 @@ void GameActivity::Update()
 
             // Set the view to a little above the LZ position
             Vector viewTarget(m_LandingZone[player].m_X, m_LandingZone[player].m_Y - (g_FrameMan.GetPlayerScreenHeight() / 4));
-            g_CameraMan.SetScrollTarget(viewTarget, 0.1, wrapped, ScreenOfPlayer(player));
+            g_CameraMan.SetScrollTarget(viewTarget, 0.1, ScreenOfPlayer(player));
         }
 
         ////////////////////////////
@@ -1854,7 +1855,7 @@ void GameActivity::Update()
             // Continuously deathwatch message
             g_FrameMan.SetScreenText("Lost control of remote body!", ScreenOfPlayer(player));
             // Don't move anything, just stay put watching the death funnies
-            g_CameraMan.SetScrollTarget(m_DeathViewTarget[player], 0.1, false, ScreenOfPlayer(player));
+            g_CameraMan.SetScrollTarget(m_DeathViewTarget[player], 0.1, ScreenOfPlayer(player));
         }
 
         ////////////////////////////////////////////////////
@@ -1863,7 +1864,7 @@ void GameActivity::Update()
 		// and double scrolling will cause CC gitch when we'll cross the seam
 		else if (m_ControlledActor[player] && m_ActivityState != ActivityState::Editing && m_ActivityState != ActivityState::PreGame)
         {
-            g_CameraMan.SetScrollTarget(m_ControlledActor[player]->GetViewPoint(), 0.1, m_ControlledActor[player]->DidWrap(), ScreenOfPlayer(player));
+            g_CameraMan.SetScrollTarget(m_ControlledActor[player]->GetViewPoint(), 0.1, ScreenOfPlayer(player));
         }
 
 		if (m_ControlledActor[player] && m_ViewState[player] != ViewState::DeathWatch && m_ViewState[player] != ViewState::ActorSelect && m_ViewState[player] != ViewState::AIGoToPoint && m_ViewState[player] != ViewState::UnitSelectCircle) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
   Mods published for any development builds must match that development version exactly.
 
+
+- `CameraMan::SetScrollTarget()` function has had the `targetWrapped` parameter removed, as it's not necessary. The camera will always focus taking the shortest path regardless now. The new full function signature is `CameraMan::SetScrollTarget(target, speed, screenId)`, where speed defaults to 0.1 and screenId defaults to 0.
+
 </details>
 
 <details><summary><b>Fixed</b></summary>
+
+- Camera wrapping now works correctly on scenes which are both X and Y wrapped.
+
 
 - Fixed music resuming from incorrect position when unpausing.
 
@@ -844,7 +850,7 @@ This can be accessed via the new Lua (R/W) `SettingsMan` property `AIUpdateInter
 	GetScreenOcclusion(screenId);
 	SetScreenOcclusion(occlusionVector, screenId);
 	GetScrollTarget(screenId);
-	SetScrollTarget(targetPosition, screenId);
+	SetScrollTarget(targetPosition, speed, screenId);
 	TargetDistanceScalar(point);
 	CheckOffset(screenId);
 	SetScroll(center, screenId);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,10 +32,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 <details><summary><b>Fixed</b></summary>
 
-- Camera wrapping now works correctly on scenes which are both X and Y wrapped.
-
-
 - Fixed music resuming from incorrect position when unpausing.
+
+- Camera wrapping now works correctly on scenes which are both X and Y wrapped.
 
 </details>
 

--- a/Managers/CameraMan.cpp
+++ b/Managers/CameraMan.cpp
@@ -75,7 +75,7 @@ namespace RTE {
 		Screen &screen = m_Screens[screenId];
 
 		// See if it would make sense to automatically wrap.
-		const SLTerrain* terrain = g_SceneMan.GetScene()->GetTerrain();
+		const SLTerrain *terrain = g_SceneMan.GetScene()->GetTerrain();
 		float targetXWrapped = terrain->WrapsX() && (std::fabs(targetCenter.GetX() - screen.ScrollTarget.GetX()) > static_cast<float>(terrain->GetBitmap()->w / 2));
 		float targetYWrapped = terrain->WrapsY() && (std::fabs(targetCenter.GetY() - screen.ScrollTarget.GetY()) > static_cast<float>(terrain->GetBitmap()->h / 2));
 

--- a/Managers/CameraMan.h
+++ b/Managers/CameraMan.h
@@ -125,9 +125,8 @@ namespace RTE {
 		/// </summary>
 		/// <param name="targetCenter">The new target vector in Scene coordinates.</param>
 		/// <param name="speed">The normalized speed at screen the view scrolls. 0 being no movement, and 1.0 being instant movement to the target in one frame.</param>
-		/// <param name="targetWrapped">Whether the target was wrapped around the scene this frame or not.</param>
 		/// <param name="screenId">Which screen you want to set the scroll offset of.</param>
-		void SetScrollTarget(const Vector &targetCenter, float speed = 0.1F, bool targetWrapped = false, int screenId = 0);
+		void SetScrollTarget(const Vector &targetCenter, float speed = 0.1F, int screenId = 0);
 
 		/// <summary>
 		/// Calculates a scalar of how distant a certain point in the world is from the currently closest scroll target of all active screens.
@@ -259,7 +258,9 @@ namespace RTE {
 			Timer ScrollTimer; //!< Scroll timer for making scrolling work framerate independently.
 			float ScrollSpeed = 0; //!< The normalized speed the screen's view scrolls. 0 being no movement, and 1.0 being instant movement to the target in one frame.
 
-			bool TargetWrapped = false; //!< Whether the ScrollTarget got wrapped around the world this frame or not.
+			bool TargetXWrapped = false; //!< Whether the ScrollTarget got x wrapped around the world this frame or not.
+			bool TargetYWrapped = false; //!< Whether the ScrollTarget got y wrapped around the world this frame or not.
+
 			std::array<int, 2> SeamCrossCount = { 0, 0 }; //!< Keeps track of how many times and in screen directions the wrapping seam has been crossed. This is used for keeping the background layers' scroll from jumping when wrapping around. X and Y.
 
 			Vector ScreenOcclusion; //!< The amount a screen is occluded or covered by GUI, etc.

--- a/Menus/AreaEditorGUI.cpp
+++ b/Menus/AreaEditorGUI.cpp
@@ -568,7 +568,7 @@ void AreaEditorGUI::Update()
     bool cursorWrapped = g_SceneMan.ForceBounds(m_CursorPos);
 // TODO: make setscrolltarget with 'sloppy' target
     // Scroll to the cursor's scene position
-    g_CameraMan.SetScrollTarget(m_CursorPos, 0.3, cursorWrapped, g_ActivityMan.GetActivity()->ScreenOfPlayer(m_pController->GetPlayer()));
+    g_CameraMan.SetScrollTarget(m_CursorPos, 0.3, g_ActivityMan.GetActivity()->ScreenOfPlayer(m_pController->GetPlayer()));
 }
 
 

--- a/Menus/AssemblyEditorGUI.cpp
+++ b/Menus/AssemblyEditorGUI.cpp
@@ -936,10 +936,10 @@ void AssemblyEditorGUI::Update()
         m_CursorOffset.Reset();
 
     // Keep the cursor position within the world
-    bool cursorWrapped = g_SceneMan.ForceBounds(m_CursorPos);
+    g_SceneMan.ForceBounds(m_CursorPos);
 // TODO: make setscrolltarget with 'sloppy' target
     // Scroll to the cursor's scene position
-    g_CameraMan.SetScrollTarget(m_CursorPos, 0.3, cursorWrapped, g_ActivityMan.GetActivity()->ScreenOfPlayer(m_pController->GetPlayer()));
+    g_CameraMan.SetScrollTarget(m_CursorPos, 0.3, g_ActivityMan.GetActivity()->ScreenOfPlayer(m_pController->GetPlayer()));
     // Apply the cursor position to the currently held object
     if (m_pCurrentObject && m_DrawCurrentObject)
     {

--- a/Menus/GibEditorGUI.cpp
+++ b/Menus/GibEditorGUI.cpp
@@ -672,10 +672,10 @@ void GibEditorGUI::Update()
         m_CursorOffset.Reset();
 
     // Keep the cursor position within the world
-    bool cursorWrapped = g_SceneMan.ForceBounds(m_CursorPos);
+    g_SceneMan.ForceBounds(m_CursorPos);
 // TODO: make setscrolltarget with 'sloppy' target
     // Scroll to the cursor's scene position
-    g_CameraMan.SetScrollTarget(m_CursorPos, 0.3, cursorWrapped, g_ActivityMan.GetActivity()->ScreenOfPlayer(m_pController->GetPlayer()));
+    g_CameraMan.SetScrollTarget(m_CursorPos, 0.3, g_ActivityMan.GetActivity()->ScreenOfPlayer(m_pController->GetPlayer()));
     // Apply the cursor position to the currently held object
     if (m_pCurrentGib && m_DrawCurrentGib)
     {

--- a/Menus/SceneEditorGUI.cpp
+++ b/Menus/SceneEditorGUI.cpp
@@ -1349,10 +1349,10 @@ void SceneEditorGUI::Update()
         m_CursorOffset.Reset();
 
     // Keep the cursor position within the world
-    bool cursorWrapped = g_SceneMan.ForceBounds(m_CursorPos);
+    g_SceneMan.ForceBounds(m_CursorPos);
 // TODO: make setscrolltarget with 'sloppy' target
     // Scroll to the cursor's scene position
-    g_CameraMan.SetScrollTarget(m_CursorPos, 0.3, cursorWrapped, g_ActivityMan.GetActivity()->ScreenOfPlayer(m_pController->GetPlayer()));
+    g_CameraMan.SetScrollTarget(m_CursorPos, 0.3, g_ActivityMan.GetActivity()->ScreenOfPlayer(m_pController->GetPlayer()));
     // Apply the cursor position to the currently held object
     if (m_pCurrentObject && m_DrawCurrentObject)
     {


### PR DESCRIPTION
Camera can now wrap correctly when the scene has both X and Y wrapping enabled.
Removed targetWrapped parameter - it's not necessary, the camera figures it out automatically.