### PR TITLE
Fix Server Input lag

### DIFF
--- a/Main.cpp
+++ b/Main.cpp
@@ -255,16 +255,14 @@ namespace RTE {
 		while (!System::IsSetToQuit()) {
 			bool serverUpdated = false;
 			updateStartTime = g_TimerMan.GetAbsoluteTime();
+			PollSDLEvents();
+			g_WindowMan.Update();
 
 			g_TimerMan.Update();
 
 			// Simulation update, as many times as the fixed update step allows in the span since last frame draw.
 			while (g_TimerMan.TimeForSimUpdate()) {
 				serverUpdated = false;
-
-				PollSDLEvents();
-
-				g_WindowMan.Update();
 
 				g_PerformanceMan.NewPerformanceSample();
 				g_PerformanceMan.UpdateMSPSU();

--- a/Main.cpp
+++ b/Main.cpp
@@ -376,6 +376,10 @@ int main(int argc, char **argv) {
 
 	HandleMainArgs(argc, argv);
 
+	if (g_NetworkServer.IsServerModeEnabled()) {
+		SDL_ShowCursor(SDL_ENABLE);
+	}
+
 	g_PresetMan.LoadAllDataModules();
 
 	if (!System::IsInExternalModuleValidationMode()) {

--- a/Managers/NetworkClient.cpp
+++ b/Managers/NetworkClient.cpp
@@ -228,43 +228,33 @@ namespace RTE {
 		msg.MouseY = static_cast<int>(mouse.GetY());
 
 		// Those are update in Update every frame to catch short events like clicks and releases
-		msg.MouseButtonPressed[MOUSE_LEFT] = m_MouseButtonPressedState[MOUSE_LEFT] == 1 ? true : false;
-		msg.MouseButtonPressed[MOUSE_MIDDLE] = m_MouseButtonPressedState[MOUSE_MIDDLE] == 1 ? true : false;
-		msg.MouseButtonPressed[MOUSE_RIGHT] = m_MouseButtonPressedState[MOUSE_RIGHT] == 1 ? true : false;
 
-		msg.MouseButtonReleased[MOUSE_LEFT] = m_MouseButtonReleasedState[MOUSE_LEFT] == 1 ? true : false;
-		msg.MouseButtonReleased[MOUSE_MIDDLE] = m_MouseButtonReleasedState[MOUSE_MIDDLE] == 1 ? true : false;
-		msg.MouseButtonReleased[MOUSE_RIGHT] = m_MouseButtonReleasedState[MOUSE_RIGHT] == 1 ? true : false;
-
-		msg.MouseButtonHeld[MOUSE_LEFT] = g_UInputMan.MouseButtonHeld(MOUSE_LEFT, -1);
-		msg.MouseButtonHeld[MOUSE_MIDDLE] = g_UInputMan.MouseButtonHeld(MOUSE_MIDDLE, -1);
-		msg.MouseButtonHeld[MOUSE_RIGHT] = g_UInputMan.MouseButtonHeld(MOUSE_RIGHT, -1);
+		msg.MouseButtonState[MOUSE_LEFT] = g_UInputMan.MouseButtonHeld(MOUSE_LEFT, -1);
+		msg.MouseButtonState[MOUSE_MIDDLE] = g_UInputMan.MouseButtonHeld(MOUSE_MIDDLE, -1);
+		msg.MouseButtonState[MOUSE_RIGHT] = g_UInputMan.MouseButtonHeld(MOUSE_RIGHT, -1);
 
 		for (int i = 0; i < MAX_MOUSE_BUTTONS; i++) {
 			m_MouseButtonPressedState[i] = -1;
 			m_MouseButtonReleasedState[i] = -1;
 		}
 		if (m_MouseWheelMoved != 0) {
+			std::cout << "Client wheel moved" << m_MouseWheelMoved << std::endl;
 			msg.MouseWheelMoved = m_MouseWheelMoved;
 			m_MouseWheelMoved = 0;
 		} else {
 			msg.MouseWheelMoved = 0;
 		}
 
-		msg.InputElementHeld = 0;
-		msg.InputElementPressed = 0;
-		msg.InputElementReleased = 0;
+		msg.InputElementState = 0;
 
-		msg.ResetActivityVote = g_UInputMan.KeyHeld(KEY_BACKSPACE) ? true : false;
-		msg.RestartActivityVote = g_UInputMan.KeyHeld(KEY_BACKSLASH) ? true : false;
+		msg.ResetActivityVote = g_UInputMan.KeyHeld(SDLK_BACKSPACE) ? true : false;
+		msg.RestartActivityVote = g_UInputMan.KeyHeld(SDLK_BACKSLASH) ? true : false;
 
 		unsigned int bitMask = 0x1;
 
 		// Store element states as bit flags
 		for (int i = 0; i < INPUT_COUNT; i++) {
-			if (g_UInputMan.ElementHeld(0, i)) { msg.InputElementHeld = msg.InputElementHeld | bitMask; }
-			if (g_UInputMan.NetworkAccumulatedElementPressed(i)) { msg.InputElementPressed = msg.InputElementPressed | bitMask; }
-			if (g_UInputMan.NetworkAccumulatedElementReleased(i)) { msg.InputElementReleased = msg.InputElementReleased | bitMask; }
+			if (g_UInputMan.ElementHeld(0, i)) { msg.InputElementState = msg.InputElementState | bitMask; }
 
 			bitMask <<= 1;
 		}

--- a/Managers/NetworkClient.cpp
+++ b/Managers/NetworkClient.cpp
@@ -238,7 +238,6 @@ namespace RTE {
 			m_MouseButtonReleasedState[i] = -1;
 		}
 		if (m_MouseWheelMoved != 0) {
-			std::cout << "Client wheel moved" << m_MouseWheelMoved << std::endl;
 			msg.MouseWheelMoved = m_MouseWheelMoved;
 			m_MouseWheelMoved = 0;
 		} else {

--- a/Managers/NetworkClient.h
+++ b/Managers/NetworkClient.h
@@ -191,8 +191,8 @@ namespace RTE {
 		int m_SceneWidth; //!<
 		int m_SceneHeight; //!<
 
-		int m_MouseButtonPressedState[3]; //!<
-		int m_MouseButtonReleasedState[3]; //!<
+		int m_MouseButtonPressedState[MAX_MOUSE_BUTTONS]; //!<
+		int m_MouseButtonReleasedState[MAX_MOUSE_BUTTONS]; //!<
 		int m_MouseWheelMoved; //!< Whether the mouse wheel was moved this Update. Used to make mouse wheel detection better.
 
 	private:

--- a/Managers/NetworkServer.cpp
+++ b/Managers/NetworkServer.cpp
@@ -538,7 +538,7 @@ namespace RTE {
 				skip = false;
 			}
 
-			if (!skip) { m_InputMessages[player].push(msg); }
+			if (!skip) { m_InputMessages[player].push_back(msg); }
 		}
 	}
 
@@ -596,9 +596,7 @@ namespace RTE {
 
 	void NetworkServer::ClearInputMessages(short player) {
 		if (player >= 0 && player < c_MaxClients) {
-			while (!m_InputMessages[player].empty()) {
-				m_InputMessages[player].pop();
-			}
+			m_InputMessages[player].clear();
 		}
 	}
 
@@ -1826,8 +1824,10 @@ namespace RTE {
 			for (short player = 0; player < c_MaxClients; player++) {
 				if (!m_InputMessages[player].empty()) {
 					MsgInput msg = m_InputMessages[player].front();
-					m_InputMessages[player].pop();
-					ProcessInputMsg(player, msg);
+					for (auto &msg: m_InputMessages[player]) {
+						ProcessInputMsg(player, msg);
+					}
+					m_InputMessages[player].clear();
 				}
 			}
 

--- a/Managers/NetworkServer.cpp
+++ b/Managers/NetworkServer.cpp
@@ -1737,7 +1737,10 @@ namespace RTE {
 			double compressionRatio = (m_DataUncompressedTotal[i] > 0) ? static_cast<double>(m_DataSentTotal[i]) / static_cast<double>(m_DataUncompressedTotal[i]) : 0;
 			double emptyRatio = (m_EmptyBlocks[i] > 0) ? static_cast<double>(m_FullBlocks[i]) / static_cast<double>(m_EmptyBlocks[i]) : 0;
 
-			std::string playerName = IsPlayerConnected(i) ? GetPlayerName(i) : "- NO PLAYER -";
+			std::string playerName = " - NO PLAYER - ";
+			if (IsPlayerConnected(i)) {
+				playerName = GetPlayerName(i);
+			}
 
 			// Jesus christ
 			std::snprintf(buf, sizeof(buf),
@@ -1747,18 +1750,18 @@ namespace RTE {
 				"R : % .2f\n"
 				"Full Blck %lu (%.1f Kb)\n"
 				"Empty Blck %lu (%.1f Kb)\n"
-				"Frame Kb : % lu\n"
-				"Glow Kb : % lu\n"
-				"Sound Kb : % lu\n"
-				"Scene Kb : % lu\n"
-				"Frames sent : % uK\n"
-				"Frame skipped : % uK\n"
-				"Blocks full : % uK\n"
-				"Blocks empty : % uK\n"
+				"Frame Kb : %lu\n"
+				"Glow Kb : %lu\n"
+				"Sound Kb : %lu\n"
+				"Scene Kb : %lu\n"
+				"Frames sent : %uK\n"
+				"Frame skipped : %uK\n"
+				"Blocks full : %uK\n"
+				"Blocks empty : %uK\n"
 				"Blk Ratio : % .2f\n"
 				"Frames ms : % d\n"
 				"Send ms % d\n"
-				"Total Data % lu MB",
+				"Total Data %lu MB",
 
 				(i == c_MaxClients) ? "- TOTALS - " : playerName.c_str(),
 				(i < c_MaxClients) ? m_Ping[i] : 0,

--- a/Managers/NetworkServer.cpp
+++ b/Managers/NetworkServer.cpp
@@ -500,18 +500,14 @@ namespace RTE {
 			msg.MouseX = m->MouseX;
 			msg.MouseY = m->MouseY;
 			for (int i = 0; i < MAX_MOUSE_BUTTONS; i++) {
-				msg.MouseButtonPressed[i] = m->MouseButtonPressed[i];
-				msg.MouseButtonReleased[i] = m->MouseButtonReleased[i];
-				msg.MouseButtonHeld[i] = m->MouseButtonHeld[i];
+				msg.MouseButtonState[i] = m->MouseButtonState[i];
 			}
 			msg.ResetActivityVote = m->ResetActivityVote;
 			msg.RestartActivityVote = m->RestartActivityVote;
 
 			msg.MouseWheelMoved = m->MouseWheelMoved;
 
-			msg.InputElementPressed = m->InputElementPressed;
-			msg.InputElementReleased = m->InputElementReleased;
-			msg.InputElementHeld = m->InputElementHeld;
+			msg.InputElementState = m->InputElementState;
 
 			bool skip = true;
 
@@ -522,18 +518,14 @@ namespace RTE {
 				if (msg.MouseY != lastmsg.MouseY) { skip = false; }
 
 				for (int i = 0; i < MAX_MOUSE_BUTTONS; i++) {
-					if (msg.MouseButtonPressed[i] != lastmsg.MouseButtonPressed[i]) { skip = false; }
-					if (msg.MouseButtonReleased[i] != lastmsg.MouseButtonReleased[i]) { skip = false; }
-					if (msg.MouseButtonHeld[i] != lastmsg.MouseButtonHeld[i]) { skip = false; }
+					if (msg.MouseButtonState[i] != lastmsg.MouseButtonState[i]) { skip = false; }
 				}
 				if (msg.ResetActivityVote != lastmsg.ResetActivityVote) { skip = false; }
 				if (msg.RestartActivityVote != lastmsg.RestartActivityVote) { skip = false; }
 
 				if (msg.MouseWheelMoved != lastmsg.MouseWheelMoved) { skip = false; }
 
-				if (msg.InputElementPressed != lastmsg.InputElementPressed) { skip = false; }
-				if (msg.InputElementReleased != lastmsg.InputElementReleased) { skip = false; }
-				if (msg.InputElementHeld != lastmsg.InputElementHeld) { skip = false; }
+				if (msg.InputElementState != lastmsg.InputElementState) { skip = false; }
 			} else {
 				skip = false;
 			}
@@ -551,19 +543,13 @@ namespace RTE {
 			input.m_Y = msg.MouseY;
 			g_UInputMan.SetNetworkMouseMovement(player, input);
 
-			g_UInputMan.SetNetworkMouseButtonHeldState(player, MOUSE_LEFT, msg.MouseButtonHeld[MOUSE_LEFT]);
-			g_UInputMan.SetNetworkMouseButtonPressedState(player, MOUSE_LEFT, msg.MouseButtonPressed[MOUSE_LEFT]);
-			g_UInputMan.SetNetworkMouseButtonReleasedState(player, MOUSE_LEFT, msg.MouseButtonReleased[MOUSE_LEFT]);
+			g_UInputMan.SetNetworkMouseButtonHeldState(player, MOUSE_LEFT, msg.MouseButtonState[MOUSE_LEFT]);
 
-			m_MouseState1[player] = (msg.MouseButtonPressed[MOUSE_LEFT] || msg.MouseButtonHeld[MOUSE_LEFT]) ? 1 : 0;
+			m_MouseState1[player] = (msg.MouseButtonState[MOUSE_LEFT]) ? 1 : 0;
 
-			g_UInputMan.SetNetworkMouseButtonHeldState(player, MOUSE_RIGHT, msg.MouseButtonHeld[MOUSE_RIGHT]);
-			g_UInputMan.SetNetworkMouseButtonPressedState(player, MOUSE_RIGHT, msg.MouseButtonPressed[MOUSE_RIGHT]);
-			g_UInputMan.SetNetworkMouseButtonReleasedState(player, MOUSE_RIGHT, msg.MouseButtonReleased[MOUSE_RIGHT]);
+			g_UInputMan.SetNetworkMouseButtonHeldState(player, MOUSE_RIGHT, msg.MouseButtonState[MOUSE_RIGHT]);
 
-			g_UInputMan.SetNetworkMouseButtonHeldState(player, MOUSE_MIDDLE, msg.MouseButtonHeld[MOUSE_MIDDLE]);
-			g_UInputMan.SetNetworkMouseButtonPressedState(player, MOUSE_MIDDLE, msg.MouseButtonPressed[MOUSE_MIDDLE]);
-			g_UInputMan.SetNetworkMouseButtonReleasedState(player, MOUSE_MIDDLE, msg.MouseButtonReleased[MOUSE_MIDDLE]);
+			g_UInputMan.SetNetworkMouseButtonHeldState(player, MOUSE_MIDDLE, msg.MouseButtonState[MOUSE_MIDDLE]);
 
 			GUIInput::SetNetworkMouseButton(player, m_MouseState1[player], m_MouseState2[player], m_MouseState3[player]);
 
@@ -573,11 +559,9 @@ namespace RTE {
 
 			// Store element states as bit flags
 			for (int i = 0; i < INPUT_COUNT; i++) {
-				bool val = (msg.InputElementHeld & bitMask) > 0;
+				bool val = (msg.InputElementState & bitMask) > 0;
 
-				g_UInputMan.SetNetworkInputElementHeldState(player, i, val);
-				g_UInputMan.SetNetworkInputElementPressedState(player, i, (msg.InputElementPressed & bitMask) > 0);
-				g_UInputMan.SetNetworkInputElementReleasedState(player, i, (msg.InputElementReleased & bitMask) > 0);
+				g_UInputMan.SetNetworkInputElementState(player, i, val);
 
 				bitMask <<= 1;
 			}

--- a/Managers/NetworkServer.cpp
+++ b/Managers/NetworkServer.cpp
@@ -1823,8 +1823,7 @@ namespace RTE {
 		if (processInput) {
 			for (short player = 0; player < c_MaxClients; player++) {
 				if (!m_InputMessages[player].empty()) {
-					MsgInput msg = m_InputMessages[player].front();
-					for (auto &msg: m_InputMessages[player]) {
+					for (const MsgInput &msg: m_InputMessages[player]) {
 						ProcessInputMsg(player, msg);
 					}
 					m_InputMessages[player].clear();

--- a/Managers/NetworkServer.h
+++ b/Managers/NetworkServer.h
@@ -276,7 +276,7 @@ namespace RTE {
 
 		std::mutex m_Mutex[c_MaxClients]; //!<
 
-		std::queue<MsgInput> m_InputMessages[c_MaxClients]; //!<
+		std::vector<MsgInput> m_InputMessages[c_MaxClients]; //!<
 
 		unsigned char m_SceneID; //!<
 

--- a/Managers/NetworkServer.h
+++ b/Managers/NetworkServer.h
@@ -276,7 +276,7 @@ namespace RTE {
 
 		std::mutex m_Mutex[c_MaxClients]; //!<
 
-		std::vector<MsgInput> m_InputMessages[c_MaxClients]; //!<
+		std::vector<MsgInput> m_InputMessages[c_MaxClients]; //!< Message Queue for received input events to be processed this frame.
 
 		unsigned char m_SceneID; //!<
 

--- a/Managers/NetworkServer.h
+++ b/Managers/NetworkServer.h
@@ -219,7 +219,7 @@ namespace RTE {
 
 		std::string m_ServerPort; //!<
 
-		ClientConnection m_ClientConnections[c_MaxClients]; //!<
+		std::array<ClientConnection, c_MaxClients> m_ClientConnections; //!<
 
 		bool m_UseNATService; //!< Whether a NAT service is used for punch-through.
 		RakNet::NatPunchthroughClient m_NATPunchthroughClient; //!<
@@ -280,8 +280,8 @@ namespace RTE {
 
 		unsigned char m_SceneID; //!<
 
-		bool m_EndActivityVotes[c_MaxClients]; //!< Votes from each player required to return to the Multiplayer Lobby.
-		bool m_RestartActivityVotes[c_MaxClients]; //!< Votes from each player required to restart the current activity.
+		std::array<bool, c_MaxClients> m_EndActivityVotes; //!< Votes from each player required to return to the Multiplayer Lobby.
+		std::array<bool, c_MaxClients> m_RestartActivityVotes; //!< Votes from each player required to restart the current activity.
 
 		long long m_LatestRestartTime; //!< The time, in ticks, that the last activity restart took place on the server.
 

--- a/Managers/TimerMan.h
+++ b/Managers/TimerMan.h
@@ -46,7 +46,7 @@ namespace RTE {
 		/// This also clears the accumulator, to avoid the case where the sim may update while paused when behind schedule.
 		/// </summary>
 		/// <param name="pause">Whether the sim should be paused or not.</param>
-		void PauseSim(bool pause = false) { m_SimPaused = pause; m_SimAccumulator = 0.0F; }
+		void PauseSim(bool pause = false) { m_SimPaused = pause; if(pause) m_SimAccumulator = 0.0F; }
 
 		/// <summary>
 		/// Tells whether there is enough sim time accumulated to do at least one physics update.

--- a/Managers/UInputMan.cpp
+++ b/Managers/UInputMan.cpp
@@ -370,7 +370,7 @@ namespace RTE {
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 	void UInputMan::TrapMousePos(bool trap, int whichPlayer) {
-		if (whichPlayer == Players::NoPlayer || m_ControlScheme.at(whichPlayer).GetDevice() == InputDevice::DEVICE_MOUSE_KEYB) {
+		if (!IsInMultiplayerMode() && (whichPlayer == Players::NoPlayer || m_ControlScheme.at(whichPlayer).GetDevice() == InputDevice::DEVICE_MOUSE_KEYB)) {
 			m_TrapMousePos = trap;
 			SDL_SetRelativeMouseMode(static_cast<SDL_bool>(trap));
 		}

--- a/Managers/UInputMan.cpp
+++ b/Managers/UInputMan.cpp
@@ -12,9 +12,6 @@
 #include "NetworkServer.h"
 
 #include "SDL.h"
-
-#include "imgui/imgui.h"
-
 namespace RTE {
 
 	std::array<uint8_t, SDL_NUM_SCANCODES> UInputMan::s_PrevKeyStates;

--- a/Managers/UInputMan.h
+++ b/Managers/UInputMan.h
@@ -570,7 +570,7 @@ namespace RTE {
 		/// </summary>
 		/// <param name="player">The player to set for.</param>
 		/// <param name="input">The new position of the mouse.</param>
-		void SetNetworkMouseMovement(int player, const Vector &input) { m_NetworkAccumulatedRawMouseMovement[player] = input; }
+		void SetNetworkMouseMovement(int player, const Vector &input) { m_NetworkAccumulatedRawMouseMovement[player] += input; }
 
 		/// <summary>
 		/// Sets whether an input element is held by a player during network multiplayer.

--- a/Managers/UInputMan.h
+++ b/Managers/UInputMan.h
@@ -625,7 +625,7 @@ namespace RTE {
 		/// </summary>
 		/// <param name="player">The player to set for.</param>
 		/// <param name="state">The new state of the mouse wheel.</param>
-		void SetNetworkMouseWheelState(int player, int state) { if (player >= Players::PlayerOne && player < Players::MaxPlayerCount) { m_NetworkMouseWheelState[player] = state; } }
+		void SetNetworkMouseWheelState(int player, int state) { if (player >= Players::PlayerOne && player < Players::MaxPlayerCount) { m_NetworkMouseWheelState[player] += state; } }
 
 		/// <summary>
 		/// Gets whether the specified input element is pressed during network multiplayer.
@@ -783,11 +783,7 @@ namespace RTE {
 		/// <param name="element">Which element to set. See InputElements enumeration.</param>
 		/// <param name="whichState">Which input state to set. See InputState enumeration.</param>
 		/// <param name="newState">The new state of the specified InputState. True or false.</param>
-		void SetNetworkInputElementState(int player, int element, InputState whichState, bool newState) {
-			if (element >= InputElements::INPUT_L_UP && element < InputElements::INPUT_COUNT && player >= Players::PlayerOne && player < Players::MaxPlayerCount) {
-				m_NetworkInputElementState[player][element][whichState] = newState;
-			}
-		}
+		void SetNetworkInputElementState(int player, int element, InputState whichState, bool newState);
 
 		/// <summary>
 		/// Sets a mouse button for a player to the specified state during network multiplayer.
@@ -796,11 +792,7 @@ namespace RTE {
 		/// <param name="whichButton">Which mouse button to set for. See MouseButtons enumeration.</param>
 		/// <param name="whichState">Which input state to set. See InputState enumeration.</param>
 		/// <param name="newState">The new state of the specified InputState. True or false.</param>
-		void SetNetworkMouseButtonState(int player, int whichButton, InputState whichState, bool newState) {
-			if (whichButton >= MouseButtons::MOUSE_LEFT && whichButton < MouseButtons::MAX_MOUSE_BUTTONS && player >= Players::PlayerOne && player < Players::MaxPlayerCount) {
-				m_NetworkMouseButtonState[player][whichButton][whichState] = newState;
-			}
-		}
+		void SetNetworkMouseButtonState(int player, int whichButton, InputState whichState, bool newState);
 
 		/// <summary>
 		/// Gets whether an input element is in the specified state during network multiplayer.

--- a/Managers/UInputMan.h
+++ b/Managers/UInputMan.h
@@ -578,23 +578,7 @@ namespace RTE {
 		/// <param name="player">Which player to set for.</param>
 		/// <param name="element">Which input element to set for.</param>
 		/// <param name="state">The new state of the input element. True or false.</param>
-		void SetNetworkInputElementHeldState(int player, int element, bool state) { SetNetworkInputElementState(player, element, InputState::Held, state); }
-
-		/// <summary>
-		/// Sets whether an input element is pressed by a player during network multiplayer.
-		/// </summary>
-		/// <param name="player">Which player to set for.</param>
-		/// <param name="element">Which input element to set for.</param>
-		/// <param name="state">The new state of the input element. True or false.</param>
-		void SetNetworkInputElementPressedState(int player, int element, bool state) { SetNetworkInputElementState(player, element, InputState::Pressed, state); }
-
-		/// <summary>
-		/// Sets whether an input element is released by a player during network multiplayer.
-		/// </summary>
-		/// <param name="player">Which player to set for.</param>
-		/// <param name="element">Which input element to set for.</param>
-		/// <param name="state">The new state of the input element. True or false.</param>
-		void SetNetworkInputElementReleasedState(int player, int element, bool state) { SetNetworkInputElementState(player, element, InputState::Released, state); }
+		void SetNetworkInputElementState(int player, int element, bool state);
 
 		/// <summary>
 		/// Sets whether a mouse button is held by a player during network multiplayer.
@@ -698,9 +682,12 @@ namespace RTE {
 		/// </summary>
 		bool m_PrepareToEnableMouseMoving;
 
-		bool m_NetworkAccumulatedElementState[InputElements::INPUT_COUNT][InputState::InputStateCount]; //!< The state of an input element during network multiplayer.
-		bool m_NetworkInputElementState[Players::MaxPlayerCount][InputElements::INPUT_COUNT][InputState::InputStateCount]; //!< The state of a player's input element during network multiplayer.
-		bool m_NetworkMouseButtonState[Players::MaxPlayerCount][MouseButtons::MAX_MOUSE_BUTTONS][InputState::InputStateCount]; //!< The state of a player's mouse button during network multiplayer.
+		bool m_NetworkAccumulatedElementState[InputElements::INPUT_COUNT][InputState::InputStateCount]; //!< The state of a client input element during network multiplayer.
+		bool m_NetworkServerChangedInputElementState[Players::MaxPlayerCount][InputElements::INPUT_COUNT]; //!< The server side state of a player's input element during network multiplayer.
+
+		std::array<std::array<bool, InputElements::INPUT_COUNT>, Players::MaxPlayerCount> m_NetworkServerPreviousInputElementState;
+		bool m_NetworkServerChangedMouseButtonState[Players::MaxPlayerCount][MouseButtons::MAX_MOUSE_BUTTONS]; //!< The state of a player's mouse button during network multiplayer.
+		std::array<std::array<bool, InputElements::INPUT_COUNT>, Players::MaxPlayerCount> m_NetworkServerPreviousMouseButtonState;
 
 		Vector m_NetworkAccumulatedRawMouseMovement[Players::MaxPlayerCount]; //!< The position of the mouse for each player during network multiplayer.
 		Vector m_NetworkAnalogMoveData[Players::MaxPlayerCount]; //!< Mouse analog movement data for each player during network multiplayer.
@@ -731,6 +718,8 @@ namespace RTE {
 		/// <param name="whichState">Which state to check for. See InputState enumeration.</param>
 		/// <returns>Whether the element is in the specified state or not.</returns>
 		bool GetInputElementState(int whichPlayer, int whichElement, InputState whichState);
+
+		bool GetNetworkInputElementState(int whichPlayer, int whichElement, InputState whichState);
 
 		/// <summary>
 		/// Gets whether any generic button with the menu cursor is in the specified state.
@@ -777,15 +766,6 @@ namespace RTE {
 		bool GetJoystickDirectionState(int whichJoy, int whichAxis, int whichDir, InputState whichState) const;
 
 		/// <summary>
-		/// Sets an input element of a player to the specified state during network multiplayer.
-		/// </summary>
-		/// <param name="player">Which player to set for. See Players enumeration.</param>
-		/// <param name="element">Which element to set. See InputElements enumeration.</param>
-		/// <param name="whichState">Which input state to set. See InputState enumeration.</param>
-		/// <param name="newState">The new state of the specified InputState. True or false.</param>
-		void SetNetworkInputElementState(int player, int element, InputState whichState, bool newState);
-
-		/// <summary>
 		/// Sets a mouse button for a player to the specified state during network multiplayer.
 		/// </summary>
 		/// <param name="player">Which player to set for. See Players enumeration.</param>
@@ -815,6 +795,11 @@ namespace RTE {
 		/// Handles the mouse input in network multiplayer. This is called from Update().
 		/// </summary>
 		void UpdateNetworkMouseMovement();
+
+		/// <summary>
+		/// Clear all NetworkServerChanged* arrays.
+		/// </summary>
+		void ClearNetworkChangedState();
 
 		/// <summary>
 		/// Handles the mouse input. This is called from Update().

--- a/Managers/WindowMan.cpp
+++ b/Managers/WindowMan.cpp
@@ -540,6 +540,9 @@ namespace RTE {
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 	void WindowMan::QueueWindowEvent(const SDL_Event &windowEvent) {
+		if (g_UInputMan.IsInMultiplayerMode()) {
+			return;
+		}
 		m_EventQueue.emplace_back(windowEvent);
 	}
 

--- a/System/NetworkMessages.h
+++ b/System/NetworkMessages.h
@@ -290,18 +290,18 @@ namespace RTE {
 
 		int MouseX;
 		int MouseY;
-		bool MouseButtonPressed[MAX_MOUSE_BUTTONS];
-		bool MouseButtonReleased[MAX_MOUSE_BUTTONS];
-		bool MouseButtonHeld[MAX_MOUSE_BUTTONS];
+		bool padMouse1[MAX_MOUSE_BUTTONS]; //< Backwards compatibility with pre5-5.1
+		bool padMouse2[MAX_MOUSE_BUTTONS];
+		bool MouseButtonState[MAX_MOUSE_BUTTONS];
 		bool ResetActivityVote;
 		bool RestartActivityVote;
 
 
 		int MouseWheelMoved;
 
-		unsigned int InputElementPressed;
-		unsigned int InputElementReleased;
-		unsigned int InputElementHeld;
+		unsigned int padElement3;
+		unsigned int padElement4;
+		unsigned int InputElementState;
 	};
 
 // Disables the previously set pack pragma.


### PR DESCRIPTION
- Fix Server to process full input queue every frame instead of one message per frame.
- Move multiplayer input handling to server
- Fix stack size of networkserver being large enough to prevent any stack allocations. (either that or I just hid some gigantic buffer overflows)
- Fix a minor buffer overflow
- Fix multiplayer sim updates never happening except for ridiculous low framerates

Changes are done such that the server remains compatible with older pre5 clients. (MsgInput packet remains with same alignment) the only client side bugfix is towards scrolling (bufferoverflow in networkclient overwriting client mousewheel)