### PR TITLE
Add StrideFrame bool to AHumans, and both the bool and OnStride function to ACrabs

### DIFF
--- a/Entities/ACrab.cpp
+++ b/Entities/ACrab.cpp
@@ -1365,12 +1365,11 @@ void ACrab::PreControllerUpdate()
 					m_StrideSound->Play();
 				}
 			}
+
             if (restarted) {
                 m_StrideFrame = true;
                 RunScriptedFunctionInAppropriateScripts("OnStride");
             }
-
-
 		} else if (m_pLFGLeg || m_pLBGLeg || m_pRFGLeg || m_pRBGLeg) {
 			if (m_MoveState == JUMP) {
 				// TODO: Utilize jump paths in an intuitive way?

--- a/Entities/ACrab.cpp
+++ b/Entities/ACrab.cpp
@@ -63,6 +63,7 @@ void ACrab::Clear()
 	m_JetReplenishRate = 1.0F;
 	m_JetAngleRange = 0.25F;
     m_MoveState = STAND;
+    m_StrideFrame = false;
     for (int side = 0; side < SIDECOUNT; ++side)
     {
         for (int layer = 0; layer < LAYERCOUNT; ++layer)
@@ -1274,6 +1275,8 @@ void ACrab::PreControllerUpdate()
     ///////////////////////////////////////////////////
     // Travel the limb AtomGroup:s
 
+    m_StrideFrame = false;
+
     if (m_Status == STABLE && !m_LimbPushForcesAndCollisionsDisabled)
     {
         // This exists to support disabling foot collisions if the limbpath has that flag set.
@@ -1362,6 +1365,12 @@ void ACrab::PreControllerUpdate()
 					m_StrideSound->Play();
 				}
 			}
+            if (restarted) {
+                m_StrideFrame = true;
+                RunScriptedFunctionInAppropriateScripts("OnStride");
+            }
+
+
 		} else if (m_pLFGLeg || m_pLBGLeg || m_pRFGLeg || m_pRBGLeg) {
 			if (m_MoveState == JUMP) {
 				// TODO: Utilize jump paths in an intuitive way?

--- a/Entities/ACrab.h
+++ b/Entities/ACrab.h
@@ -424,7 +424,6 @@ int FirearmActivationDelay() const;
 	/// Gets whether this ACrab has just taken a stride this frame.
 	/// </summary>
 	/// <returns>Whether this ACrab has taken a stride this frame or not.</returns>
-
 	bool StrideFrame() const { return m_StrideFrame; }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/Entities/ACrab.h
+++ b/Entities/ACrab.h
@@ -67,6 +67,7 @@ public:
 
 // Concrete allocation and cloning definitions
 	EntityAllocation(ACrab);
+	AddScriptFunctionNames(Actor, "OnStride");
 	SerializableOverrideMethods;
 	ClassInfoGetters;
 	DefaultPieMenuNameGetter(HasObjectInGroup("Turrets") ? "Default Turret Pie Menu" : "Default Crab Pie Menu");
@@ -419,6 +420,13 @@ int FirearmActivationDelay() const;
 	BITMAP * GetGraphicalIcon() const override;
 
 
+	/// <summary>
+	/// Gets whether this ACrab has just taken a stride this frame.
+	/// </summary>
+	/// <returns>Whether this ACrab has taken a stride this frame or not.</returns>
+
+	bool StrideFrame() const { return m_StrideFrame; }
+
 //////////////////////////////////////////////////////////////////////////////////////////
 // Virtual method:  PreControllerUpdate
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -604,6 +612,8 @@ protected:
 	Timer m_IconBlinkTimer;
 	// Current movement state.
 	MovementState m_MoveState;
+	// Whether a stride was taken this frame or not.
+	bool m_StrideFrame = false;
 	// Limb paths for different movement states.
 	// First which side, then which background/foreground, then the movement state
 	LimbPath m_Paths[SIDECOUNT][LAYERCOUNT][MOVEMENTSTATECOUNT];

--- a/Entities/AHuman.cpp
+++ b/Entities/AHuman.cpp
@@ -71,6 +71,7 @@ void AHuman::Clear()
     m_Aiming = false;
     m_ArmClimbing[FGROUND] = false;
     m_ArmClimbing[BGROUND] = false;
+	m_StrideFrame = false;
     m_StrideStart = false;
     m_JetTimeTotal = 0.0;
     m_JetTimeLeft = 0.0;
@@ -2263,6 +2264,8 @@ void AHuman::PreControllerUpdate()
     ///////////////////////////////////////////////////
     // Travel the limb AtomGroup:s
 
+	m_StrideFrame = false;
+
 	if (m_Status == STABLE && !m_LimbPushForcesAndCollisionsDisabled && m_MoveState != NOMOVE)
     {
         // This exists to support disabling foot collisions if the limbpath has that flag set.
@@ -2323,6 +2326,7 @@ void AHuman::PreControllerUpdate()
 					m_WalkAngle[FGROUND] = Matrix();
 					m_WalkAngle[BGROUND] = Matrix();
 				} else {
+					m_StrideFrame = true;
 					RunScriptedFunctionInAppropriateScripts("OnStride");
 				}
 			}

--- a/Entities/AHuman.h
+++ b/Entities/AHuman.h
@@ -795,6 +795,13 @@ DefaultPieMenuNameGetter("Default Human Pie Menu");
 	void SetWalkAngle(AHuman::Layer whichLayer, float angle) { m_WalkAngle[whichLayer] = Matrix(angle); }
 
 	/// <summary>
+	/// Gets whether this AHuman has just taken a stride this frame.
+	/// </summary>
+	/// <returns>Whether this AHuman has taken a stride this frame or not.</returns>
+
+    bool StrideFrame() const { return m_StrideFrame; }
+
+	/// <summary>
 	/// Gets whether this AHuman is currently attempting to climb something, using arms.
 	/// </summary>
 	/// <returns>Whether this AHuman is currently climbing or not.</returns>
@@ -1036,6 +1043,8 @@ protected:
     bool m_Aiming;
     // Whether the BG Arm is helping with locomotion or not.
     bool m_ArmClimbing[2];
+    // Whether a stride was taken this frame or not.
+    bool m_StrideFrame = false;
     // Controls the start of leg synch.
     bool m_StrideStart;
     // Times the stride to see if it is taking too long and needs restart

--- a/Entities/AHuman.h
+++ b/Entities/AHuman.h
@@ -798,7 +798,6 @@ DefaultPieMenuNameGetter("Default Human Pie Menu");
 	/// Gets whether this AHuman has just taken a stride this frame.
 	/// </summary>
 	/// <returns>Whether this AHuman has taken a stride this frame or not.</returns>
-
     bool StrideFrame() const { return m_StrideFrame; }
 
 	/// <summary>

--- a/Lua/LuaBindingsEntities.cpp
+++ b/Lua/LuaBindingsEntities.cpp
@@ -62,6 +62,7 @@ namespace RTE {
 		.property("RightFGLeg", &ACrab::GetRightFGLeg, &LuaAdaptersPropertyOwnershipSafetyFaker::ACrabSetRightFGLeg)
 		.property("RightBGLeg", &ACrab::GetRightBGLeg, &LuaAdaptersPropertyOwnershipSafetyFaker::ACrabSetRightBGLeg)
 		.property("StrideSound", &ACrab::GetStrideSound, &LuaAdaptersPropertyOwnershipSafetyFaker::ACrabSetStrideSound)
+		.property("StrideFrame", &ACrab::StrideFrame)
 		.property("JetTimeTotal", &ACrab::GetJetTimeTotal, &ACrab::SetJetTimeTotal)
 		.property("JetTimeLeft", &ACrab::GetJetTimeLeft)
 		.property("JetReplenishRate", &ACrab::GetJetReplenishRate, &ACrab::SetJetReplenishRate)
@@ -452,6 +453,7 @@ namespace RTE {
 		.property("FirearmActivationDelay", &AHuman::FirearmActivationDelay)
 		.property("LimbPathPushForce", &AHuman::GetLimbPathPushForce, &AHuman::SetLimbPathPushForce)
 		.property("IsClimbing", &AHuman::IsClimbing)
+		.property("StrideFrame", &AHuman::StrideFrame)
 		.property("ArmSwingRate", &AHuman::GetArmSwingRate, &AHuman::SetArmSwingRate)
 		.property("DeviceArmSwayRate", &AHuman::GetDeviceArmSwayRate, &AHuman::SetDeviceArmSwayRate)
 


### PR DESCRIPTION
the bool is lua readable making it useful if you want a script to read whether an external actor just took a stride that frame, which OnStride does not allow. it's also useful if you want to do something with StrideFrame in the middle of an Update function rather than wherever OnStride is currently placed.

ACrabs also didn't even have the OnStride function so i've added both the bool and the function to them. it's dupe code technically, but no other way to do it currently.