### PR TITLE
Sound Improvements

### DIFF
--- a/Entities/Actor.cpp
+++ b/Entities/Actor.cpp
@@ -1375,8 +1375,6 @@ void Actor::Update()
 		const float impulse = std::sqrt(travelImpulseMagnitudeSqr) - m_TravelImpulseDamage;
 		const float damage = std::max(impulse / (m_GibImpulseLimit - m_TravelImpulseDamage) * m_MaxHealth, 0.0F);
 		m_Health -= damage;
-		// Replaced by PainThreshold mechanic, no sudden wusses if damage is ground-inflicted
-		//if (damage > 0 && m_Health > 0 && m_PainSound) { m_PainSound->Play(m_Pos); }
 		if (m_Status == Actor::STABLE) { m_Status = UNSTABLE; }
 		m_ForceDeepCheck = true;
 	}

--- a/Entities/Actor.cpp
+++ b/Entities/Actor.cpp
@@ -103,6 +103,7 @@ void Actor::Clear() {
     m_LastAlarmPos.Reset();
     m_SightDistance = 450.0F;
     m_Perceptiveness = 0.5F;
+    m_PainThreshold = 15.0F;
 	m_CanRevealUnseen = true;
     m_CharHeight = 0;
     m_HolsterOffset.Reset();
@@ -221,6 +222,7 @@ int Actor::Create(const Actor &reference)
     m_SeenTargetPos = reference.m_SeenTargetPos;
     m_SightDistance = reference.m_SightDistance;
     m_Perceptiveness = reference.m_Perceptiveness;
+    m_PainThreshold = reference.m_PainThreshold;
 	m_CanRevealUnseen = reference.m_CanRevealUnseen;
     m_CharHeight = reference.m_CharHeight;
     m_HolsterOffset = reference.m_HolsterOffset;
@@ -363,6 +365,8 @@ int Actor::ReadProperty(const std::string_view &propName, Reader &reader)
         reader >> m_SightDistance;
     else if (propName == "Perceptiveness")
         reader >> m_Perceptiveness;
+    else if (propName == "PainThreshold")
+        reader >> m_PainThreshold;
 	else if (propName == "CanRevealUnseen")
 		reader >> m_CanRevealUnseen;
     else if (propName == "CharHeight")
@@ -455,6 +459,8 @@ int Actor::Save(Writer &writer) const
     writer << m_SightDistance;
     writer.NewProperty("Perceptiveness");
     writer << m_Perceptiveness;
+    writer.NewProperty("PainThreshold");
+    writer << m_PainThreshold;
 	writer.NewProperty("CanRevealUnseen");
 	writer << m_CanRevealUnseen;
     writer.NewProperty("CharHeight");
@@ -1369,7 +1375,8 @@ void Actor::Update()
 		const float impulse = std::sqrt(travelImpulseMagnitudeSqr) - m_TravelImpulseDamage;
 		const float damage = std::max(impulse / (m_GibImpulseLimit - m_TravelImpulseDamage) * m_MaxHealth, 0.0F);
 		m_Health -= damage;
-		if (damage > 0 && m_Health > 0 && m_PainSound) { m_PainSound->Play(m_Pos); }
+		// Replaced by PainThreshold mechanic, no sudden wusses if damage is ground-inflicted
+		//if (damage > 0 && m_Health > 0 && m_PainSound) { m_PainSound->Play(m_Pos); }
 		if (m_Status == Actor::STABLE) { m_Status = UNSTABLE; }
 		m_ForceDeepCheck = true;
 	}
@@ -1445,6 +1452,9 @@ void Actor::Update()
     {
         g_MovableMan.SortTeamRoster(m_Team);
     }
+
+    // Play PainSound if damage this frame exceeded PainThreshold
+    if (m_PainThreshold > 0 && m_PrevHealth - m_Health > m_PainThreshold && m_Health > 1 && m_PainSound) { m_PainSound->Play(m_Pos); }
 
 	int brainOfPlayer = g_ActivityMan.GetActivity()->IsBrainOfWhichPlayer(this);
 	if (brainOfPlayer != Players::NoPlayer && g_ActivityMan.GetActivity()->PlayerHuman(brainOfPlayer)) {

--- a/Entities/Actor.h
+++ b/Entities/Actor.h
@@ -805,6 +805,23 @@ ClassInfoGetters;
 	/// <param name="newCanRevealUnseen">Whether this actor can reveal unseen areas.</param>
 	void SetCanRevealUnseen(bool newCanRevealUnseen) { m_CanRevealUnseen = newCanRevealUnseen; }
 
+//////////////////////////////////////////////////////////////////////////////////////////
+// Method:  SetPainThreshold
+//////////////////////////////////////////////////////////////////////////////////////////
+// Description:     Sets this' PainThreshold value above which it will play PainSound
+// Arguments:       Desired PainThreshold value
+// Return value:    None.
+
+    void SetPainThreshold(float newPainThreshold) { m_PainThreshold = newPainThreshold; }
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// Method:  GetPainThreshold
+//////////////////////////////////////////////////////////////////////////////////////////
+// Description:     Gets this' PainThreshold value above which it will play PainSound
+// Arguments:       None.
+// Return value:    The current PainThreshold
+
+    float GetPainThreshold() const { return m_PainThreshold; }
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // Method:  AlarmPoint
@@ -1464,6 +1481,8 @@ protected:
     float m_SightDistance;
     // How perceptive this is of alarming events going on around him, 0.0 - 1.0
     float m_Perceptiveness;
+    /// Damage value above which this will play PainSound
+    float m_PainThreshold;
 	// Whether or not this actor can reveal unseen areas by looking
 	bool m_CanRevealUnseen;
     // About How tall is the Actor, in pixels?

--- a/Entities/HDFirearm.cpp
+++ b/Entities/HDFirearm.cpp
@@ -48,6 +48,8 @@ void HDFirearm::Clear()
     m_EmptySound = nullptr;
 	m_ReloadStartSound = nullptr;
     m_ReloadEndSound = nullptr;
+    m_ReloadEndOffsetSeconds = -1.0F;
+    m_HasPlayedEndReloadSound = false;
     m_RateOfFire = 0;
     m_ActivationDelay = 0;
     m_DeactivationDelay = 0;
@@ -129,6 +131,7 @@ int HDFirearm::Create(const HDFirearm &reference) {
 	if (reference.m_EmptySound) { m_EmptySound = dynamic_cast<SoundContainer *>(reference.m_EmptySound->Clone()); }
 	if (reference.m_ReloadStartSound) { m_ReloadStartSound = dynamic_cast<SoundContainer *>(reference.m_ReloadStartSound->Clone()); }
 	if (reference.m_ReloadEndSound) { m_ReloadEndSound = dynamic_cast<SoundContainer *>(reference.m_ReloadEndSound->Clone()); }
+    m_ReloadEndOffsetSeconds = reference.m_ReloadEndOffsetSeconds;
 	m_RateOfFire = reference.m_RateOfFire;
     m_ActivationDelay = reference.m_ActivationDelay;
     m_DeactivationDelay = reference.m_DeactivationDelay;
@@ -203,6 +206,8 @@ int HDFirearm::ReadProperty(const std::string_view &propName, Reader &reader) {
 	} else if (propName == "ReloadEndSound") {
 		m_ReloadEndSound = new SoundContainer;
 		reader >> m_ReloadEndSound;
+    } else if (propName == "ReloadEndOffsetSeconds") {
+        reader >> m_ReloadEndOffsetSeconds;
 	} else if (propName == "RateOfFire") {
         reader >> m_RateOfFire;
     } else if (propName == "ActivationDelay") {
@@ -296,6 +301,7 @@ int HDFirearm::Save(Writer &writer) const
     writer << m_ReloadStartSound;
     writer.NewProperty("ReloadEndSound");
     writer << m_ReloadEndSound;
+    writer.NewPropertyWithValue("ReloadEndOffsetSeconds", m_ReloadEndOffsetSeconds);
     writer.NewProperty("RateOfFire");
     writer << m_RateOfFire;
     writer.NewProperty("ActivationDelay");
@@ -979,15 +985,26 @@ void HDFirearm::Update()
         m_AlreadyClicked = true;
     }
 
+    if (m_Reloading && m_ReloadEndSound) {
+        float offsetSeconds = m_ReloadEndOffsetSeconds == -1.0F ? m_ReloadEndSound->GetLength(SoundContainer::LengthOfSoundType::NextPlayed) : m_ReloadEndOffsetSeconds;
+        bool shouldPlay = !m_HasPlayedEndReloadSound && m_ReloadTmr.LeftTillSimTimeLimitS() <= offsetSeconds;
+        if (shouldPlay) {
+            m_ReloadEndSound->Play(m_Pos);
+            m_HasPlayedEndReloadSound = true;
+        }
+    }
+
 	if (m_Reloading && !m_pMagazine && m_pMagazineReference && m_ReloadTmr.IsPastSimTimeLimit()) {
 		SetMagazine(dynamic_cast<Magazine *>(m_pMagazineReference->Clone()));
-		if (m_ReloadEndSound) { m_ReloadEndSound->Play(m_Pos); }
 
 		m_ActivationTimer.Reset();
 		m_LastFireTmr.Reset();
 
-		if (m_PreFireSound && m_Activated) { m_PreFireSound->Play(); }
+		if (m_PreFireSound && m_Activated) { 
+            m_PreFireSound->Play(); 
+        }
 
+        m_HasPlayedEndReloadSound = false;
 		m_Reloading = false;
 		m_DoneReloading = true;
 	}

--- a/Entities/HDFirearm.cpp
+++ b/Entities/HDFirearm.cpp
@@ -987,8 +987,8 @@ void HDFirearm::Update()
 
     if (m_Reloading && m_ReloadEndSound) {
         // x0.5 the sound length generally just lines up better and leaves less dead air assuming a normal attempt at a ReloadEnd sound
-        float offsetSeconds = m_ReloadEndOffset == -1.0F ? m_ReloadEndSound->GetLength(SoundContainer::LengthOfSoundType::NextPlayed) * 0.5f : m_ReloadEndOffset;
-        bool shouldPlay = !m_HasPlayedEndReloadSound && m_ReloadTmr.LeftTillSimTimeLimitS() <= offsetSeconds;
+        float offsetMilliseconds = m_ReloadEndOffset == -1.0F ? m_ReloadEndSound->GetLength(SoundContainer::LengthOfSoundType::NextPlayed) * 0.5f : m_ReloadEndOffset;
+        bool shouldPlay = !m_HasPlayedEndReloadSound && m_ReloadTmr.LeftTillSimTimeLimitMS() <= offsetMilliseconds;
         if (shouldPlay) {
             m_ReloadEndSound->Play(m_Pos);
             m_HasPlayedEndReloadSound = true;

--- a/Entities/HDFirearm.cpp
+++ b/Entities/HDFirearm.cpp
@@ -48,7 +48,7 @@ void HDFirearm::Clear()
     m_EmptySound = nullptr;
 	m_ReloadStartSound = nullptr;
     m_ReloadEndSound = nullptr;
-    m_ReloadEndOffsetSeconds = -1.0F;
+    m_ReloadEndOffset = -1.0F;
     m_HasPlayedEndReloadSound = false;
     m_RateOfFire = 0;
     m_ActivationDelay = 0;
@@ -131,7 +131,7 @@ int HDFirearm::Create(const HDFirearm &reference) {
 	if (reference.m_EmptySound) { m_EmptySound = dynamic_cast<SoundContainer *>(reference.m_EmptySound->Clone()); }
 	if (reference.m_ReloadStartSound) { m_ReloadStartSound = dynamic_cast<SoundContainer *>(reference.m_ReloadStartSound->Clone()); }
 	if (reference.m_ReloadEndSound) { m_ReloadEndSound = dynamic_cast<SoundContainer *>(reference.m_ReloadEndSound->Clone()); }
-    m_ReloadEndOffsetSeconds = reference.m_ReloadEndOffsetSeconds;
+    m_ReloadEndOffset = reference.m_ReloadEndOffset;
 	m_RateOfFire = reference.m_RateOfFire;
     m_ActivationDelay = reference.m_ActivationDelay;
     m_DeactivationDelay = reference.m_DeactivationDelay;
@@ -206,8 +206,8 @@ int HDFirearm::ReadProperty(const std::string_view &propName, Reader &reader) {
 	} else if (propName == "ReloadEndSound") {
 		m_ReloadEndSound = new SoundContainer;
 		reader >> m_ReloadEndSound;
-    } else if (propName == "ReloadEndOffsetSeconds") {
-        reader >> m_ReloadEndOffsetSeconds;
+    } else if (propName == "ReloadEndOffset") {
+        reader >> m_ReloadEndOffset;
 	} else if (propName == "RateOfFire") {
         reader >> m_RateOfFire;
     } else if (propName == "ActivationDelay") {
@@ -301,7 +301,7 @@ int HDFirearm::Save(Writer &writer) const
     writer << m_ReloadStartSound;
     writer.NewProperty("ReloadEndSound");
     writer << m_ReloadEndSound;
-    writer.NewPropertyWithValue("ReloadEndOffsetSeconds", m_ReloadEndOffsetSeconds);
+    writer.NewPropertyWithValue("ReloadEndOffset", m_ReloadEndOffset);
     writer.NewProperty("RateOfFire");
     writer << m_RateOfFire;
     writer.NewProperty("ActivationDelay");
@@ -986,7 +986,8 @@ void HDFirearm::Update()
     }
 
     if (m_Reloading && m_ReloadEndSound) {
-        float offsetSeconds = m_ReloadEndOffsetSeconds == -1.0F ? m_ReloadEndSound->GetLength(SoundContainer::LengthOfSoundType::NextPlayed)/2 : m_ReloadEndOffsetSeconds;
+        // x0.5 the sound length generally just lines up better and leaves less dead air assuming a normal attempt at a ReloadEnd sound
+        float offsetSeconds = m_ReloadEndOffset == -1.0F ? m_ReloadEndSound->GetLength(SoundContainer::LengthOfSoundType::NextPlayed) * 0.5f : m_ReloadEndOffset;
         bool shouldPlay = !m_HasPlayedEndReloadSound && m_ReloadTmr.LeftTillSimTimeLimitS() <= offsetSeconds;
         if (shouldPlay) {
             m_ReloadEndSound->Play(m_Pos);

--- a/Entities/HDFirearm.cpp
+++ b/Entities/HDFirearm.cpp
@@ -986,7 +986,7 @@ void HDFirearm::Update()
     }
 
     if (m_Reloading && m_ReloadEndSound) {
-        float offsetSeconds = m_ReloadEndOffsetSeconds == -1.0F ? m_ReloadEndSound->GetLength(SoundContainer::LengthOfSoundType::NextPlayed) : m_ReloadEndOffsetSeconds;
+        float offsetSeconds = m_ReloadEndOffsetSeconds == -1.0F ? m_ReloadEndSound->GetLength(SoundContainer::LengthOfSoundType::NextPlayed)/2 : m_ReloadEndOffsetSeconds;
         bool shouldPlay = !m_HasPlayedEndReloadSound && m_ReloadTmr.LeftTillSimTimeLimitS() <= offsetSeconds;
         if (shouldPlay) {
             m_ReloadEndSound->Play(m_Pos);

--- a/Entities/HDFirearm.h
+++ b/Entities/HDFirearm.h
@@ -108,25 +108,25 @@ AddScriptFunctionNames(HeldDevice, "OnFire", "OnReload");
     void Destroy(bool notInherited = false) override;
 
 //////////////////////////////////////////////////////////////////////////////////////////
-// Method:  GetReloadEndOffsetSeconds
+// Method:  GetReloadEndOffset
 //////////////////////////////////////////////////////////////////////////////////////////
-// Description:     Gets reload end offset, in seconds. This is how early the ReloadEnd
+// Description:     Gets reload end offset, in ms. This is how early the ReloadEnd
 //					sound is played compared to actual end of reload.
 // Arguments:       None.
-// Return value:    The reload end offset, in seconds.
+// Return value:    The reload end offset, in ms.
 
-	int GetReloadEndOffsetSeconds() const { return m_ReloadEndOffsetSeconds; }
+	int GetReloadEndOffset() const { return m_ReloadEndOffset; }
 
 
 //////////////////////////////////////////////////////////////////////////////////////////
-// Method:  SetReloadEndOffsetSeconds
+// Method:  SetReloadEndOffset
 //////////////////////////////////////////////////////////////////////////////////////////
-// Description:     Sets reload end offset, in seconds. This is how early the ReloadEnd
+// Description:     Sets reload end offset, in ms. This is how early the ReloadEnd
 //					sound is played compared to actual end of reload.
-// Arguments:       The new reload end offset, in seconds.
+// Arguments:       The new reload end offset, in ms
 // Return value:    None.
 
-	void SetReloadEndOffsetSeconds(int newRate) { m_ReloadEndOffsetSeconds = newRate; }
+	void SetReloadEndOffset(int newRate) { m_ReloadEndOffset = newRate; }
 
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -917,7 +917,7 @@ protected:
     SoundContainer *m_ReloadStartSound;
     SoundContainer *m_ReloadEndSound;
 	// The offset of how long before the reload finishes the sound plays
-	float m_ReloadEndOffsetSeconds;
+	float m_ReloadEndOffset;
 	// Whether or not the end-of-relaod sound has already been played or not.
 	bool m_HasPlayedEndReloadSound;
 

--- a/Entities/HDFirearm.h
+++ b/Entities/HDFirearm.h
@@ -895,6 +895,10 @@ protected:
     // The audio of this FireArm being reloaded.
     SoundContainer *m_ReloadStartSound;
     SoundContainer *m_ReloadEndSound;
+	// The offset of how long before the reload finishes the sound plays
+	float m_ReloadEndOffsetSeconds;
+	// Whether or not the end-of-relaod sound has already been played or not.
+	bool m_HasPlayedEndReloadSound;
 
     // Rate of fire, in rounds per min.
     // If 0, firearm is semi-automatic (ie only one discharge per activation).

--- a/Entities/HDFirearm.h
+++ b/Entities/HDFirearm.h
@@ -123,7 +123,7 @@ AddScriptFunctionNames(HeldDevice, "OnFire", "OnReload");
 //////////////////////////////////////////////////////////////////////////////////////////
 // Description:     Sets reload end offset, in ms. This is how early the ReloadEnd
 //					sound is played compared to actual end of reload.
-// Arguments:       The new reload end offset, in ms
+// Arguments:       The new reload end offset, in ms.
 // Return value:    None.
 
 	void SetReloadEndOffset(int newRate) { m_ReloadEndOffset = newRate; }

--- a/Entities/HDFirearm.h
+++ b/Entities/HDFirearm.h
@@ -107,6 +107,27 @@ AddScriptFunctionNames(HeldDevice, "OnFire", "OnReload");
 
     void Destroy(bool notInherited = false) override;
 
+//////////////////////////////////////////////////////////////////////////////////////////
+// Method:  GetReloadEndOffsetSeconds
+//////////////////////////////////////////////////////////////////////////////////////////
+// Description:     Gets reload end offset, in seconds. This is how early the ReloadEnd
+//					sound is played compared to actual end of reload.
+// Arguments:       None.
+// Return value:    The reload end offset, in seconds.
+
+	int GetReloadEndOffsetSeconds() const { return m_ReloadEndOffsetSeconds; }
+
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// Method:  SetReloadEndOffsetSeconds
+//////////////////////////////////////////////////////////////////////////////////////////
+// Description:     Sets reload end offset, in seconds. This is how early the ReloadEnd
+//					sound is played compared to actual end of reload.
+// Arguments:       The new reload end offset, in seconds.
+// Return value:    None.
+
+	void SetReloadEndOffsetSeconds(int newRate) { m_ReloadEndOffsetSeconds = newRate; }
+
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // Method:  GetRateOfFire

--- a/Entities/SoundContainer.cpp
+++ b/Entities/SoundContainer.cpp
@@ -153,6 +153,28 @@ namespace RTE {
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+	float SoundContainer::GetLength(LengthOfSoundType type) const {
+		if (!m_SoundPropertiesUpToDate) {
+			// Todo - use a post-load fixup stage instead of lazily initializing shit everywhere... Eugh.
+			const_cast<SoundContainer *>(this)->UpdateSoundProperties();
+			const_cast<SoundContainer*>(this)->m_TopLevelSoundSet.SelectNextSounds();
+		}
+
+		std::vector<const SoundSet::SoundData*> flattenedSoundData;
+		m_TopLevelSoundSet.GetFlattenedSoundData(flattenedSoundData, type == LengthOfSoundType::NextPlayed);
+
+		float lengthSeconds = 0.0f;
+		for (const SoundSet::SoundData *selectedSoundData : flattenedSoundData) {
+			unsigned int length;
+			selectedSoundData->SoundObject->getLength(&length, FMOD_TIMEUNIT_MS);
+			lengthSeconds = std::max(lengthSeconds, static_cast<float>(length) / 1000.0f);
+		}
+
+		return lengthSeconds;
+	}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 	std::vector<std::size_t> SoundContainer::GetSelectedSoundHashes() const {
 		std::vector<size_t> soundHashes;
 		std::vector<const SoundSet::SoundData *> flattenedSoundData;

--- a/Entities/SoundContainer.cpp
+++ b/Entities/SoundContainer.cpp
@@ -163,14 +163,14 @@ namespace RTE {
 		std::vector<const SoundSet::SoundData*> flattenedSoundData;
 		m_TopLevelSoundSet.GetFlattenedSoundData(flattenedSoundData, type == LengthOfSoundType::NextPlayed);
 
-		float lengthSeconds = 0.0f;
+		float lengthMilliseconds = 0.0f;
 		for (const SoundSet::SoundData *selectedSoundData : flattenedSoundData) {
 			unsigned int length;
 			selectedSoundData->SoundObject->getLength(&length, FMOD_TIMEUNIT_MS);
-			lengthSeconds = std::max(lengthSeconds, static_cast<float>(length) / 1000.0f);
+			lengthMilliseconds = std::max(lengthMilliseconds, static_cast<float>(length));
 		}
 
-		return lengthSeconds;
+		return lengthMilliseconds;
 	}
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Entities/SoundContainer.h
+++ b/Entities/SoundContainer.h
@@ -91,7 +91,7 @@ namespace RTE {
 		/// Gets the length of the sound in this sound container.
 		/// </summary>
 		/// <param name="type">Whether to get the length of the next played sound, or the maximum length of any sound in this container.</param>
-		/// <returns>The length of this sound, in seconds.</returns>
+		/// <returns>The length of this sound, in ms.</returns>
 		float GetLength(LengthOfSoundType type) const;
 
 		/// <summary>

--- a/Entities/SoundContainer.h
+++ b/Entities/SoundContainer.h
@@ -82,6 +82,18 @@ namespace RTE {
 		/// <returns>Whether this SoundContainer has any sounds.</returns>
 		bool HasAnySounds() const { return m_TopLevelSoundSet.HasAnySounds(); }
 
+		enum class LengthOfSoundType {
+			Any,
+			NextPlayed
+		};
+
+		/// <summary>
+		/// Gets the length of the sound in this sound container.
+		/// </summary>
+		/// <param name="type">Whether to get the length of the next played sound, or the maximum length of any sound in this container.</param>
+		/// <returns>The length of this sound, in seconds.</returns>
+		float GetLength(LengthOfSoundType type) const;
+
 		/// <summary>
 		/// Gets a reference to the top level SoundSet of this SoundContainer, to which all SoundData and sub SoundSets belong.
 		/// </summary>

--- a/Entities/SoundSet.cpp
+++ b/Entities/SoundSet.cpp
@@ -305,9 +305,11 @@ namespace RTE {
 				}
 				RTEAssert(m_CurrentSelection.second >= 0 && m_CurrentSelection.second < selectedVectorSize, "Failed to select next sound, either none was selected or the selected sound was invalid.");
 		}
+
 		if (m_CurrentSelection.first == true) {
 			return m_SubSoundSets[m_CurrentSelection.second].SelectNextSounds();
 		}
+
 		return true;
 	}
 }

--- a/Lua/LuaBindingsEntities.cpp
+++ b/Lua/LuaBindingsEntities.cpp
@@ -677,7 +677,7 @@ namespace RTE {
 	LuaBindingRegisterFunctionDefinitionForType(EntityLuaBindings, HDFirearm) {
 		return ConcreteTypeLuaClassDefinition(HDFirearm, HeldDevice)
 
-		.property("ReloadEndOffsetSeconds", &HDFirearm::GetReloadEndOffsetSeconds, &HDFirearm::SetReloadEndOffsetSeconds)
+		.property("ReloadEndOffset", &HDFirearm::GetReloadEndOffset, &HDFirearm::SetReloadEndOffset)
 		.property("RateOfFire", &HDFirearm::GetRateOfFire, &HDFirearm::SetRateOfFire)
 		.property("MSPerRound", &HDFirearm::GetMSPerRound)
 		.property("FullAuto", &HDFirearm::IsFullAuto, &HDFirearm::SetFullAuto)

--- a/Lua/LuaBindingsEntities.cpp
+++ b/Lua/LuaBindingsEntities.cpp
@@ -677,6 +677,7 @@ namespace RTE {
 	LuaBindingRegisterFunctionDefinitionForType(EntityLuaBindings, HDFirearm) {
 		return ConcreteTypeLuaClassDefinition(HDFirearm, HeldDevice)
 
+		.property("ReloadEndOffsetSeconds", &HDFirearm::GetReloadEndOffsetSeconds, &HDFirearm::SetReloadEndOffsetSeconds)
 		.property("RateOfFire", &HDFirearm::GetRateOfFire, &HDFirearm::SetRateOfFire)
 		.property("MSPerRound", &HDFirearm::GetMSPerRound)
 		.property("FullAuto", &HDFirearm::IsFullAuto, &HDFirearm::SetFullAuto)

--- a/Lua/LuaBindingsEntities.cpp
+++ b/Lua/LuaBindingsEntities.cpp
@@ -235,6 +235,7 @@ namespace RTE {
 		.property("DeploymentID", &Actor::GetDeploymentID)
 		.property("PassengerSlots", &Actor::GetPassengerSlots, &Actor::SetPassengerSlots)
 		.property("Perceptiveness", &Actor::GetPerceptiveness, &Actor::SetPerceptiveness)
+		.property("PainThreshold", &Actor::GetPainThreshold, &Actor::SetPainThreshold)
 		.property("CanRevealUnseen", &Actor::GetCanRevealUnseen, &Actor::SetCanRevealUnseen)
 		.property("InventorySize", &Actor::GetInventorySize)
 		.property("MaxInventoryMass", &Actor::GetMaxInventoryMass)

--- a/Managers/AudioMan.cpp
+++ b/Managers/AudioMan.cpp
@@ -568,14 +568,11 @@ namespace RTE {
 
 		if (!soundContainer->SoundPropertiesUpToDate()) {
 			result = soundContainer->UpdateSoundProperties();
+			soundContainer->GetTopLevelSoundSet().SelectNextSounds();
 			if (result != FMOD_OK) {
 				g_ConsoleMan.PrintString("ERROR: Could not update sound properties for SoundContainer " + soundContainer->GetPresetName() + ": " + std::string(FMOD_ErrorString(result)));
 				return false;
 			}
-		}
-		if (!soundContainer->GetTopLevelSoundSet().SelectNextSounds()) {
-			g_ConsoleMan.PrintString("Unable to select new sounds to play for SoundContainer " + soundContainer->GetPresetName());
-			return false;
 		}
 
 		FMOD::ChannelGroup *channelGroupToPlayIn;
@@ -624,7 +621,14 @@ namespace RTE {
 			soundContainer->AddPlayingChannel(channelIndex);
 		}
 
-		if (m_IsInMultiplayerMode) { RegisterSoundEvent(player, SOUND_PLAY, soundContainer); }
+		if (m_IsInMultiplayerMode) { 
+			RegisterSoundEvent(player, SOUND_PLAY, soundContainer); 
+		}
+
+		// Choose the sounds for next time
+		bool choseNext = soundContainer->GetTopLevelSoundSet().SelectNextSounds();
+		RTEAssert(choseNext, "Unable to select new sounds to play for SoundContainer " + soundContainer->GetPresetName());
+
 		return true;
 	}
 

--- a/System/Timer.h
+++ b/System/Timer.h
@@ -156,14 +156,14 @@ namespace RTE {
 		/// <summary>
 		/// Returns how much time in ms that there is left till this Timer reaches a certain time limit previously set by SetRealTimeLimitMS.
 		/// </summary>
-		/// <returns>A unsigned long with the real time left till the passed in value, or negative if this Timer is already past that point in time.</returns>
-		double LeftTillRealTimeLimitMS() { return (m_RealTimeLimit / m_TicksPerMS) - GetElapsedRealTimeMS(); }
+		/// <returns>How many MS left till the real time limit, or negative if this Timer is already past that point in time.</returns>
+		double LeftTillRealTimeLimitMS() { return GetRealTimeLimitMS() - GetElapsedRealTimeMS(); }
 
 		/// <summary>
 		/// Returns how much time in ms that there is left till this Timer reaches a certain time limit previously set by SetRealTimeLimitS.
 		/// </summary>
-		/// <returns>A unsigned long with the real time left till the passed in value, or negative if this Timer is already past that point in time.</returns>
-		double LeftTillRealTimeLimitS() { return (m_RealTimeLimit * static_cast<double>(g_TimerMan.GetTicksPerSecond())) - GetElapsedRealTimeS(); }
+		/// <returns>How many S left till the real time limit, or negative if this Timer is already past that point in time.</returns>
+		double LeftTillRealTimeLimitS() { return GetRealTimeLimitS() - GetElapsedRealTimeS(); }
 
 		/// <summary>
 		/// Returns true if the elapsed real time is past a certain amount of time after the start previously set by SetRealTimeLimit.
@@ -269,14 +269,14 @@ namespace RTE {
 		/// <summary>
 		/// Returns how much time in ms that there is left till this Timer reaches a certain time limit previously set by SetSimTimeLimitMS.
 		/// </summary>
-		/// <returns>A unsigned long with the sim time left till the passed in value, or negative if this Timer is already past that point in time.</returns>
-		double LeftTillSimTimeLimitMS() const { return (m_SimTimeLimit / m_TicksPerMS) - GetElapsedSimTimeMS(); }
+		/// <returns>How many MS left till the sim time limit, or negative if this Timer is already past that point in time.</returns>
+		double LeftTillSimTimeLimitMS() const { return GetSimTimeLimitMS() - GetElapsedSimTimeMS(); }
 
 		/// <summary>
 		/// Returns how much time in ms that there is left till this Timer reaches a certain time limit previously set by SetSimTimeLimitS.
 		/// </summary>
-		/// <returns>A unsigned long with the sim time left till the passed in value, or negative if this Timer is already past that point in time.</returns>
-		double LeftTillSimTimeLimitS() const { return (m_SimTimeLimit * static_cast<double>(g_TimerMan.GetTicksPerSecond())) - GetElapsedSimTimeS(); }
+		/// <returns>How many S left till the real time limit, or negative if this Timer is already past that point in time.</returns>
+		double LeftTillSimTimeLimitS() const { return GetSimTimeLimitS() - GetElapsedSimTimeS(); }
 
 		/// <summary>
 		/// Returns true if the elapsed sim time is past a certain amount of time after the start previously set by SetSimTimeLimit.


### PR DESCRIPTION
Play reload end sounds so that they coincide with the end of the reload, instead of starting always after the reload has finished.
Expose information to API about how long the next played sound in a soundcontainer is.
Fixes to timer.