### PR TITLE
Fix postprocess matrix transform order

### DIFF
--- a/Managers/PostProcessMan.cpp
+++ b/Managers/PostProcessMan.cpp
@@ -534,7 +534,7 @@ namespace RTE {
 				effectStrength = postEffect.m_Strength / 255.f;
 				effectPosX = postEffect.m_Pos.m_X;
 				effectPosY = postEffect.m_Pos.m_Y;
-				m_PostProcessShader->SetVector4f(m_PostProcessShader->GetColorUniform(), glm::vec4(effectStrength));
+				m_PostProcessShader->SetVector4f(m_PostProcessShader->GetColorUniform(), glm::vec4(effectStrength, effectStrength, effectStrength, 1.0f));
 
 				glm::mat4 transformMatrix(1);
 				transformMatrix = glm::translate(transformMatrix, glm::vec3(effectPosX, effectPosY, 0));

--- a/Managers/PostProcessMan.cpp
+++ b/Managers/PostProcessMan.cpp
@@ -538,8 +538,8 @@ namespace RTE {
 
 				glm::mat4 transformMatrix(1);
 				transformMatrix = glm::translate(transformMatrix, glm::vec3(effectPosX, effectPosY, 0));
-				transformMatrix = glm::scale(transformMatrix, glm::vec3(effectBitmap->w * 0.5f, effectBitmap->h * 0.5f, 1.0));
 				transformMatrix = glm::rotate(transformMatrix, -postEffect.m_Angle, glm::vec3(0, 0, 1));
+				transformMatrix = glm::scale(transformMatrix, glm::vec3(effectBitmap->w * 0.5f, effectBitmap->h * 0.5f, 1.0));
 
 				glBindTexture(GL_TEXTURE_2D, reinterpret_cast<GLBitmapInfo*>(postEffect.m_Bitmap->extra)->m_Texture);
 				m_PostProcessShader->SetMatrix4f(m_PostProcessShader->GetTransformUniform(), transformMatrix);


### PR DESCRIPTION
was dumb, used rotate scale translate should be scale rotate translate
- fix slightly weaker glows due to added alpha