### PR TITLE
Screenshot fixes

### DIFF
--- a/Main.cpp
+++ b/Main.cpp
@@ -130,6 +130,7 @@ namespace RTE {
 		g_LuaMan.Destroy();
 		ContentFile::FreeAllLoaded();
 		g_ConsoleMan.Destroy();
+		g_WindowMan.Destroy();
 
 #ifdef DEBUG_BUILD
 		Entity::ClassInfo::DumpPoolMemoryInfo(Writer("MemCleanupInfo.txt"));

--- a/Managers/ConsoleMan.cpp
+++ b/Managers/ConsoleMan.cpp
@@ -255,7 +255,7 @@ namespace RTE {
 			SetReadOnly();
 		}
 
-		if (!g_UInputMan.FlagShiftState() && (!g_UInputMan.FlagCtrlState() && g_UInputMan.KeyPressed(SDL_SCANCODE_GRAVE))) {
+		if (!g_UInputMan.FlagShiftState() && (!g_UInputMan.FlagCtrlState() && (g_UInputMan.KeyPressed(SDL_SCANCODE_GRAVE) || (IsEnabled() && g_UInputMan.KeyPressed(SDL_SCANCODE_ESCAPE))))) {
 			if (IsEnabled()) {
 				if (!m_ReadOnly) {
 					m_InputTextBox->SetEnabled(false);

--- a/Managers/PresetMan.cpp
+++ b/Managers/PresetMan.cpp
@@ -334,8 +334,11 @@ bool PresetMan::IsModuleUserdata(const std::string &moduleName) const {
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 std::string PresetMan::GetFullModulePath(const std::string &modulePath) const {
+	// Note: Mods may use mixed path separators, which aren't supported on non Windows systems.
+	// Since Windows supports both forward and backslash separators it's safe to replace all backslashes with forward slashes.
 	std::string modulePathGeneric = std::filesystem::path(modulePath).generic_string();
 	std::replace(modulePathGeneric.begin(), modulePathGeneric.end(), '\\', '/');
+
 	const std::string pathTopDir = modulePathGeneric.substr(0, modulePathGeneric.find_first_of("/") + 1);
 	const std::string moduleName = GetModuleNameFromPath(modulePathGeneric);
 

--- a/Managers/PresetMan.cpp
+++ b/Managers/PresetMan.cpp
@@ -334,8 +334,9 @@ bool PresetMan::IsModuleUserdata(const std::string &moduleName) const {
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 std::string PresetMan::GetFullModulePath(const std::string &modulePath) const {
-	const std::string modulePathGeneric = std::filesystem::path(modulePath).generic_string();
-	const std::string pathTopDir = modulePathGeneric.substr(0, modulePathGeneric.find_first_of("/\\") + 1);
+	std::string modulePathGeneric = std::filesystem::path(modulePath).generic_string();
+	std::replace(modulePathGeneric.begin(), modulePathGeneric.end(), '\\', '/');
+	const std::string pathTopDir = modulePathGeneric.substr(0, modulePathGeneric.find_first_of("/") + 1);
 	const std::string moduleName = GetModuleNameFromPath(modulePathGeneric);
 
 	std::string moduleTopDir = System::GetModDirectory();

--- a/Managers/UInputMan.cpp
+++ b/Managers/UInputMan.cpp
@@ -903,7 +903,6 @@ namespace RTE {
 			}
 			// Ctrl+R or Back button for controllers to reset activity.
 			if (!g_MetaMan.GameInProgress() && !g_ActivityMan.ActivitySetToRestart()) {
-				g_ActivityMan.SetRestartActivity(FlagCtrlState() && KeyPressed(SDLK_r) || AnyBackPress());
 				g_ActivityMan.SetRestartActivity((FlagCtrlState() && KeyPressed(SDLK_r)) || AnyBackPress());
 			}
 			if (g_ActivityMan.ActivitySetToRestart()) {

--- a/Managers/WindowMan.cpp
+++ b/Managers/WindowMan.cpp
@@ -84,6 +84,14 @@ namespace RTE {
 
 	WindowMan::~WindowMan() = default;
 
+	void WindowMan::Destroy() {
+		glDeleteTextures(1, &m_BackBuffer32Texture);
+		glDeleteBuffers(1, &m_ScreenVBO);
+		glDeleteVertexArrays(1, &m_ScreenVAO);
+		glDeleteTextures(1, &m_ScreenBufferTexture);
+		glDeleteFramebuffers(1, &m_ScreenBufferFBO);
+	}
+
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 	void WindowMan::Initialize() {
@@ -205,6 +213,9 @@ namespace RTE {
 		glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float), (void *)(2 * sizeof(float)));
 		glEnableVertexAttribArray(1);
 		glBindVertexArray(0);
+		glGenTextures(1, &m_BackBuffer32Texture);
+		glGenTextures(1, &m_ScreenBufferTexture);
+		glGenFramebuffers(1, &m_ScreenBufferFBO);
 	}
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -213,6 +224,10 @@ namespace RTE {
 		glDeleteTextures(1, &m_BackBuffer32Texture);
 		glGenTextures(1, &m_BackBuffer32Texture);
 		glBindTexture(GL_TEXTURE_2D, m_BackBuffer32Texture);
+		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, m_ResX, m_ResY, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+		glBindTexture(GL_TEXTURE_2D, m_ScreenBufferTexture);
 		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, m_ResX, m_ResY, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);

--- a/Managers/WindowMan.cpp
+++ b/Managers/WindowMan.cpp
@@ -221,8 +221,6 @@ namespace RTE {
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 	void WindowMan::CreateBackBufferTexture() {
-		glDeleteTextures(1, &m_BackBuffer32Texture);
-		glGenTextures(1, &m_BackBuffer32Texture);
 		glBindTexture(GL_TEXTURE_2D, m_BackBuffer32Texture);
 		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, m_ResX, m_ResY, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
@@ -739,12 +737,13 @@ namespace RTE {
 
 	void WindowMan::UploadFrame() {
 		glDisable(GL_DEPTH_TEST);
-		GL_CHECK(glBindFramebuffer(GL_FRAMEBUFFER, 0));
-		GL_CHECK(glActiveTexture(GL_TEXTURE0));
 
-		int windowW, windowH;
-		SDL_GL_GetDrawableSize(m_PrimaryWindow.get(), &windowW, &windowH);
-		GL_CHECK(glViewport(0, 0, windowW, windowH));
+		GL_CHECK(glBindFramebuffer(GL_FRAMEBUFFER, m_ScreenBufferFBO));
+		GL_CHECK(glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_ScreenBufferTexture, 0));
+		GL_CHECK(glClearColor(0.0f, 0.0f, 0.0f, 1.0f));
+		GL_CHECK(glClear(GL_COLOR_BUFFER_BIT));
+		GL_CHECK(glActiveTexture(GL_TEXTURE0));
+		glViewport(0, 0, m_ResX, m_ResY);
 
 		glEnable(GL_BLEND);
 		if (m_DrawPostProcessBuffer) {
@@ -765,10 +764,17 @@ namespace RTE {
 		m_ScreenBlitShader->Use();
 		m_ScreenBlitShader->SetInt(m_ScreenBlitShader->GetTextureUniform(), 0);
 		m_ScreenBlitShader->SetInt(m_ScreenBlitShader->GetUniformLocation("rteGUITexture"), 1);
+		m_ScreenBlitShader->SetMatrix4f(m_ScreenBlitShader->GetProjectionUniform(), glm::mat4(1.0f));
+		m_ScreenBlitShader->SetMatrix4f(m_ScreenBlitShader->GetTransformUniform(), glm::scale(glm::mat4(1.0f), {1.0f, -1.0f, 1.0f}));
+		GL_CHECK(glDrawArrays(GL_TRIANGLE_STRIP, 0, 4));
+		GL_CHECK(glBindFramebuffer(GL_FRAMEBUFFER, 0));
+		GL_CHECK(glActiveTexture(GL_TEXTURE0));
+		GL_CHECK(glBindTexture(GL_TEXTURE_2D, 0));
+		GL_CHECK(glActiveTexture(GL_TEXTURE1));
+		GL_CHECK(glBindTexture(GL_TEXTURE_2D, m_ScreenBufferTexture));
 		if (m_MultiDisplayWindows.empty()) {
 			glViewport(m_PrimaryWindowViewport->x, m_PrimaryWindowViewport->y, m_PrimaryWindowViewport->w, m_PrimaryWindowViewport->h);
-			m_ScreenBlitShader->SetMatrix4f(m_ScreenBlitShader->GetProjectionUniform(), glm::mat4(1.0f));
-			m_ScreenBlitShader->SetMatrix4f(m_ScreenBlitShader->GetTransformUniform(), glm::mat4(1.0f));
+		m_ScreenBlitShader->SetMatrix4f(m_ScreenBlitShader->GetTransformUniform(), glm::mat4(1.0f));
 			GL_CHECK(glDrawArrays(GL_TRIANGLE_STRIP, 0, 4));
 			SDL_GL_SwapWindow(m_PrimaryWindow.get());
 		} else {

--- a/Managers/WindowMan.cpp
+++ b/Managers/WindowMan.cpp
@@ -774,7 +774,7 @@ namespace RTE {
 		GL_CHECK(glBindTexture(GL_TEXTURE_2D, m_ScreenBufferTexture));
 		if (m_MultiDisplayWindows.empty()) {
 			glViewport(m_PrimaryWindowViewport->x, m_PrimaryWindowViewport->y, m_PrimaryWindowViewport->w, m_PrimaryWindowViewport->h);
-		m_ScreenBlitShader->SetMatrix4f(m_ScreenBlitShader->GetTransformUniform(), glm::mat4(1.0f));
+			m_ScreenBlitShader->SetMatrix4f(m_ScreenBlitShader->GetTransformUniform(), glm::mat4(1.0f));
 			GL_CHECK(glDrawArrays(GL_TRIANGLE_STRIP, 0, 4));
 			SDL_GL_SwapWindow(m_PrimaryWindow.get());
 		} else {

--- a/Managers/WindowMan.h
+++ b/Managers/WindowMan.h
@@ -59,6 +59,11 @@ namespace RTE {
 		/// Destructor method used to clean up a WindowMan object before deletion from system memory.
 		/// </summary>
 		~WindowMan();
+
+		/// <summary>
+		/// Clean up GL pointers.
+		/// </summary>
+		void Destroy();
 #pragma endregion
 
 #pragma region Getters and Setters
@@ -164,6 +169,12 @@ namespace RTE {
 		/// </summary>
 		/// <returns>The absolute top-most position in the OS display arrangement.</returns>
 		int GetDisplayArrangementAbsOffsetY() const { return std::abs(m_DisplayArrangementTopMostOffset); }
+
+		/// <summary>
+		/// Get the screen buffer texture.
+		/// </summary>
+		/// <returns>The screen buffer texture.</returns>
+		GLuint GetScreenBufferTexture() const { return m_ScreenBufferTexture; }
 #pragma endregion
 
 #pragma region Resolution Change Handling
@@ -247,7 +258,9 @@ namespace RTE {
 		bool m_FocusEventsDispatchedByDisplaySwitchIn; //!< Whether queued events were dispatched due to raising windows when taking focus of any game window in the previous update.
 
 		std::shared_ptr<SDL_Window> m_PrimaryWindow; //!< The main window.
-		GLuint m_BackBuffer32Texture; //!< The main window renderer's drawing surface.
+		GLuint m_BackBuffer32Texture; //!< Streaming texture for the software rendered stuff.
+		GLuint m_ScreenBufferTexture; //!< Internal backbuffer for the final blit and sceenshots, only clear immediately before drawing.
+		GLuint m_ScreenBufferFBO; //!< Framebuffer object for the screen buffer texture.
 		glm::mat4 m_PrimaryWindowProjection; //!< Projection Matrix for the main window.
 		std::unique_ptr<SDL_Rect> m_PrimaryWindowViewport; //!< Viewport for the main window.
 


### PR DESCRIPTION
- Add intermediate semi persistent renderbuffer for screenshots etc.
  - screen buffer gets cleared immediately before upload
- Make escape close the console
- add gpu abort screen dump (front buffer since that's usually somewhat available even under assert conditions)
- Make screenshots just be rendered resolution, helps with odd window resolution scaling issues
