### PR TITLE
Jetpack minimum fuel ratio mechanic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ compile_commands.json
 
 /enc_temp_folder
 
+/.idea
 /_Bin
 /NATPunchServer/Server/NATCompleteServer/Debug
 /NATPunchServer/Server/NATCompleteServer/Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - New `AEJetpack` type, which replaces the old technique of `ACrab`/`AHuman` using an `AEmitter` as a jetpack. This type inherits from `AEmitter`.  
 	New INI and Lua (R/W) property `JetpackType`, which can be either `AEJetpack.Standard` or `AEJetpack.JumpPack`. Standard acts the same as the typical jetpack, whereas JumpPacks can only be activated when fully recharged, and fires all of it's fuel in one burst. Defaults to Standard.  
+	New INI and Lua (R/W) property `MinimumFuelRatio`, which defines the ratio of current fuel to max fuel that has to be met to fire the jetpack. Defaults to 0 for Standard and 0.25 for JumpPacks.
 	New INI and Lua (R/W) property `CanAdjustAngleWhileFiring`, which defines whether the jet angle can change while the jetpack is active. Defaults to true.  
 	New INI and Lua (R/W) property `AdjustsThrottleForWeight`, which defines whether the jetpack will adjust it's throttle (between `NegativeThrottleMultiplier` and `PositiveThrottleMultiplier`) to account for any extra inventory mass. Increased throttle will decrease jet time accordingly. Defaults to true.  
 

--- a/Entities/AEJetpack.cpp
+++ b/Entities/AEJetpack.cpp
@@ -145,7 +145,7 @@ namespace RTE {
 			case JetpackType::Standard:
 				if (controller.IsState(BODY_JUMPSTART) && !IsOutOfFuel() && IsFullyFueled()) {
 					Burst(parentActor, fuelUseMultiplier);
-				} else if (controller.IsState(BODY_JUMP) && !IsOutOfFuel() && GetJetTimeRatio() >= m_MinimumFuelRatio) {
+				} else if (controller.IsState(BODY_JUMP) && !IsOutOfFuel() && (GetJetTimeRatio() >= m_MinimumFuelRatio || wasEmittingLastFrame)) {
 					Thrust(parentActor, fuelUseMultiplier);
 				} else {
 					Recharge(parentActor);

--- a/Entities/AEJetpack.cpp
+++ b/Entities/AEJetpack.cpp
@@ -15,7 +15,7 @@ namespace RTE {
         m_JetTimeLeft = 0.0F;
 		m_JetThrustBonusMultiplier = 1.0F;
         m_JetReplenishRate = 1.0F;
-		m_MinimumFuel = 0.0F;
+		m_MinimumFuelRatio = 0.0F;
         m_JetAngleRange = 0.25F;
 		m_CanAdjustAngleWhileFiring = true;
 		m_AdjustsThrottleForWeight = true;
@@ -44,7 +44,7 @@ namespace RTE {
         m_JetTimeTotal = reference.m_JetTimeTotal;
         m_JetTimeLeft = reference.m_JetTimeLeft;
         m_JetReplenishRate = reference.m_JetReplenishRate;
-		m_MinimumFuel = reference.m_MinimumFuel;
+		m_MinimumFuelRatio = reference.m_MinimumFuelRatio;
         m_JetAngleRange = reference.m_JetAngleRange;
 		m_CanAdjustAngleWhileFiring = reference.m_CanAdjustAngleWhileFiring;
 		m_AdjustsThrottleForWeight = reference.m_AdjustsThrottleForWeight;
@@ -64,7 +64,7 @@ namespace RTE {
 				m_JetpackType = JetpackType::Standard;
 			} else if (jetpackType == "JumpPack") {
 				m_JetpackType = JetpackType::JumpPack;
-				m_MinimumFuel = 0.25F;
+				m_MinimumFuelRatio = 0.25F;
 			} else {
 				reader.ReportError("Unknown JetpackType '" + jetpackType + "'!");
 			}
@@ -74,9 +74,9 @@ namespace RTE {
             m_JetTimeTotal *= 1000.0f; // Convert to ms
 	    });
 		MatchForwards("JumpReplenishRate") MatchProperty("JetReplenishRate", { reader >> m_JetReplenishRate; });
-		MatchProperty("MinimumFuel", {
-			reader >> m_MinimumFuel;
-			m_MinimumFuel = std::clamp(m_MinimumFuel, 0.0F, 1.0F);
+		MatchProperty("MinimumFuelRatio", {
+			reader >> m_MinimumFuelRatio;
+			m_MinimumFuelRatio = std::clamp(m_MinimumFuelRatio, 0.0F, 1.0F);
 		});		
 		MatchForwards("JumpAngleRange") MatchProperty("JetAngleRange", { reader >> m_JetAngleRange; });
 		MatchProperty("CanAdjustAngleWhileFiring", { reader >> m_CanAdjustAngleWhileFiring; });
@@ -103,7 +103,7 @@ namespace RTE {
 
 		writer.NewPropertyWithValue("JumpTime", m_JetTimeTotal / 1000.0f); // Convert to seconds
 		writer.NewPropertyWithValue("JumpReplenishRate", m_JetReplenishRate);
-		writer.NewPropertyWithValue("MinimumFuel", m_MinimumFuel);
+		writer.NewPropertyWithValue("MinimumFuelRatio", m_MinimumFuelRatio);
 		writer.NewPropertyWithValue("JumpAngleRange", m_JetAngleRange);
 		writer.NewPropertyWithValue("CanAdjustAngleWhileFiring", m_CanAdjustAngleWhileFiring);
 		writer.NewPropertyWithValue("AdjustsThrottleForWeight", m_AdjustsThrottleForWeight);
@@ -145,7 +145,7 @@ namespace RTE {
 			case JetpackType::Standard:
 				if (controller.IsState(BODY_JUMPSTART) && !IsOutOfFuel() && IsFullyFueled()) {
 					Burst(parentActor, fuelUseMultiplier);
-				} else if (controller.IsState(BODY_JUMP) && !IsOutOfFuel() && GetJetTimeRatio() >= m_MinimumFuel) {
+				} else if (controller.IsState(BODY_JUMP) && !IsOutOfFuel() && GetJetTimeRatio() >= m_MinimumFuelRatio) {
 					Thrust(parentActor, fuelUseMultiplier);
 				} else {
 					Recharge(parentActor);
@@ -155,7 +155,7 @@ namespace RTE {
 			case JetpackType::JumpPack:
 				if (wasEmittingLastFrame && !IsOutOfFuel()) {
 					Thrust(parentActor, fuelUseMultiplier);
-				} else if (controller.IsState(BODY_JUMPSTART) && GetJetTimeRatio() >= m_MinimumFuel) {
+				} else if (controller.IsState(BODY_JUMPSTART) && GetJetTimeRatio() >= m_MinimumFuelRatio) {
 					Burst(parentActor, fuelUseMultiplier);
 				} else {
 					Recharge(parentActor);

--- a/Entities/AEJetpack.h
+++ b/Entities/AEJetpack.h
@@ -116,6 +116,18 @@ namespace RTE
         void SetJetReplenishRate(float newValue) { m_JetReplenishRate = newValue; }
 
         /// <summary>
+        /// Gets the rate at which this AHuman's jetpack is replenished during downtime.
+        /// </summary>
+        /// <returns>The rate at which the jetpack is replenished.</returns>
+        float GetMinimumFuelRatio() const { return m_MinimumFuelRatio; }
+
+        /// <summary>
+        /// Sets the rate at which this AHuman's jetpack is replenished during downtime.
+        /// </summary>
+        /// <param name="newValue">The rate at which the jetpack is replenished.</param>
+        void SetMinimumFuelRatio(float newValue) { m_MinimumFuelRatio = newValue; }
+
+        /// <summary>
         /// Gets the scalar ratio at which this jetpack's thrust angle follows the aim angle of the user.
         /// </summary>
         /// <returns>The ratio at which this jetpack follows the aim angle of the user.</returns>
@@ -171,7 +183,7 @@ namespace RTE
         float m_JetTimeLeft; //!< How much time left the jetpack can go, in ms
         float m_JetThrustBonusMultiplier; //!< A multiplier bonus to our produced thrust, which doesn't cost extra fuel. Used for AI buffs.
         float m_JetReplenishRate; //!< A multiplier affecting how fast the jetpack fuel will replenish when not in use. 1 means that jet time replenishes at 2x speed in relation to depletion.
-        float m_MinimumFuel; // Minimum ratio of current fuel to max fuel to be able to initiate the JumpPack. Does nothing if standard jetpack.
+        float m_MinimumFuelRatio; // Minimum ratio of current fuel to max fuel to be able to initiate the jetpack.
         float m_JetAngleRange; //!< Ratio at which the jetpack angle follows aim angle
         bool m_CanAdjustAngleWhileFiring; //!< Whether or not the angle of the thrust can change while firing, or if it can only be adjusted while the jetpack is off
         bool m_AdjustsThrottleForWeight; //!< Whether or not the jetpack throttle auto-adjusts for weight, at the cost of fuel usage.

--- a/Entities/AEJetpack.h
+++ b/Entities/AEJetpack.h
@@ -171,6 +171,7 @@ namespace RTE
         float m_JetTimeLeft; //!< How much time left the jetpack can go, in ms
         float m_JetThrustBonusMultiplier; //!< A multiplier bonus to our produced thrust, which doesn't cost extra fuel. Used for AI buffs.
         float m_JetReplenishRate; //!< A multiplier affecting how fast the jetpack fuel will replenish when not in use. 1 means that jet time replenishes at 2x speed in relation to depletion.
+        float m_MinimumFuel; // Minimum ratio of current fuel to max fuel to be able to initiate the JumpPack. Does nothing if standard jetpack.
         float m_JetAngleRange; //!< Ratio at which the jetpack angle follows aim angle
         bool m_CanAdjustAngleWhileFiring; //!< Whether or not the angle of the thrust can change while firing, or if it can only be adjusted while the jetpack is off
         bool m_AdjustsThrottleForWeight; //!< Whether or not the jetpack throttle auto-adjusts for weight, at the cost of fuel usage.

--- a/Entities/Scene.cpp
+++ b/Entities/Scene.cpp
@@ -1550,6 +1550,7 @@ void Scene::SaveSceneObject(Writer &writer, const SceneObject *sceneObjectToSave
 
             writer.NewPropertyWithValue("JumpTime", jetpackToSave->GetJetTimeTotal() / 1000.0f); // Convert to seconds
             writer.NewPropertyWithValue("JumpReplenishRate", jetpackToSave->GetJetReplenishRate());
+        	writer.NewPropertyWithValue("MinimumFuelRatio", jetpackToSave->GetMinimumFuelRatio());
             writer.NewPropertyWithValue("JumpAngleRange", jetpackToSave->GetJetAngleRange());
             writer.NewPropertyWithValue("CanAdjustAngleWhileFiring", jetpackToSave->GetCanAdjustAngleWhileFiring());
         }

--- a/Lua/LuaBindingsEntities.cpp
+++ b/Lua/LuaBindingsEntities.cpp
@@ -431,6 +431,7 @@ namespace RTE {
 		.property("JetTimeTotal", &AEJetpack::GetJetTimeTotal, &AEJetpack::SetJetTimeTotal)
 		.property("JetTimeLeft", &AEJetpack::GetJetTimeLeft)
 		.property("JetReplenishRate", &AEJetpack::GetJetReplenishRate, &AEJetpack::SetJetReplenishRate)
+		.property("MinimumFuelRatio", &AEJetpack::GetMinimumFuelRatio, &AEJetpack::SetMinimumFuelRatio)
 		.property("JetAngleRange", &AEJetpack::GetJetAngleRange, &AEJetpack::SetJetAngleRange)
 		.property("CanAdjustAngleWhileFiring", &AEJetpack::GetCanAdjustAngleWhileFiring, &AEJetpack::SetCanAdjustAngleWhileFiring)
 		.property("AdjustsThrottleForWeight", &AEJetpack::GetAdjustsThrottleForWeight, &AEJetpack::SetAdjustsThrottleForWeight)


### PR DESCRIPTION
add MinimumFuelRatio INI and Lua R/W property which denotes the ratio of current fuel to max fuel that has to be met for the jetpack to be firable. defaults to 0 for jetpacks and 0.25 for JumpPacks.