### PR TITLE
BuyableMode, Buyable cleanup, ResetSensorTimer lua bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,11 +103,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - New `ADoor` Lua function `ResetSensorTimer()`. Resets the sensor timer for that door, making it take the full SensorInterval again for it to detect actors.
 
-- New `SceneObject` Lua functions `IsBuyableInScriptOnly()`, `IsBuyableInObjectPickerOnly()`, and `IsBuyableInBuyMenuOnly()`. 
-
 - Exposed `SceneObject` property `BuyableMode` to Lua (R).
 
-- `Enum` binding for `SceneObject.BuyableMode`: `NORESTRICTIONS = 0, BUYMENUONLY = 1, OBJECTPICKERONLY = 2, SCRIPTONLY = 2`.  
+- `Enum` binding for `SceneObject.BuyableMode`: `NORESTRICTIONS = 0, BUYMENUONLY = 1, OBJECTPICKERONLY = 2, SCRIPTONLY = 3`.  
 
 </details>
 
@@ -149,7 +147,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Script values, i.e `GetStringValue`, `RemoveStringValue`, `StringValueExists` and the associated functions for `GetNumberValue`/`GetObjectValue`, have been moved from MOSRotating to MovableObject, so now any object with script support can use these values.  
 
-- The `SceneObject` property `IsBuyable` is now a function, e.g. `IsBuyable()`. `Buyable` replaces it as a property.
+- The `SceneObject` property `IsBuyable` has been renamed to `Buyable`.
 
 </details>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - New `Scene` Lua functions `AddNavigatableArea(areaName)` and `ClearNavigatableAreas()`. This can be used to restrict pathfinding to only search a set of areas that have been added to the scene before via `Scene:SetArea(area)`.
 
+- New `ADoor` Lua function `ResetSensorTimer()`. Resets the sensor timer for that door, making it take the full SensorInterval again for it to detect actors.
+
+- New `SceneObject` Lua functions `IsBuyableInScriptOnly()`, `IsBuyableInObjectPickerOnly()`, and `IsBuyableInBuyMenuOnly()`. 
+
 </details>
 
 <details><summary><b>Changed</b></summary>
@@ -140,6 +144,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Improved loading times on large maps.  
 
 - Script values, i.e `GetStringValue`, `RemoveStringValue`, `StringValueExists` and the associated functions for `GetNumberValue`/`GetObjectValue`, have been moved from MOSRotating to MovableObject, so now any object with script support can use these values.  
+
+- The `SceneObject` property `IsBuyable` is now a function, e.g. `IsBuyable()`.
 
 </details>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - New `SceneObject` Lua functions `IsBuyableInScriptOnly()`, `IsBuyableInObjectPickerOnly()`, and `IsBuyableInBuyMenuOnly()`. 
 
+- Exposed `SceneObject` property `BuyableMode` to Lua (R).
+
+- `Enum` binding for `SceneObject.BuyableMode`: `NORESTRICTIONS = 0, BUYMENUONLY = 1, OBJECTPICKERONLY = 2, SCRIPTONLY = 2`.  
+
 </details>
 
 <details><summary><b>Changed</b></summary>
@@ -145,7 +149,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Script values, i.e `GetStringValue`, `RemoveStringValue`, `StringValueExists` and the associated functions for `GetNumberValue`/`GetObjectValue`, have been moved from MOSRotating to MovableObject, so now any object with script support can use these values.  
 
-- The `SceneObject` property `IsBuyable` is now a function, e.g. `IsBuyable()`.
+- The `SceneObject` property `IsBuyable` is now a function, e.g. `IsBuyable()`. `Buyable` replaces it as a property.
 
 </details>
 

--- a/Entities/SceneObject.h
+++ b/Entities/SceneObject.h
@@ -464,6 +464,12 @@ public:
 
     bool IsBuyable() const { return m_Buyable; }
 
+    /// <summary>
+    /// Gets the BuyableMode of this SceneObject.
+    /// </summary>
+    /// <returns>The BuyableMode of this SceneObject</returns>
+    BuyableMode GetBuyableMode() const { return m_BuyableMode; }
+
 	/// <summary>
 	/// Gets whether this SceneObject is available only in the BuyMenu list when buyable.
 	/// </summary>

--- a/Lua/LuaBindingsEntities.cpp
+++ b/Lua/LuaBindingsEntities.cpp
@@ -1338,11 +1338,13 @@ namespace RTE {
 		.property("RotAngle", &SceneObject::GetRotAngle, &SceneObject::SetRotAngle)
 		.property("Team", &SceneObject::GetTeam, &SceneObject::SetTeam)
 		.property("PlacedByPlayer", &SceneObject::GetPlacedByPlayer, &SceneObject::SetPlacedByPlayer)
+		.property("Buyable", &SceneObject::IsBuyable)
+		.property("BuyableMode", &SceneObject::GetBuyableMode)
 		
 		.def("IsBuyable", &SceneObject::IsBuyable)
-		.def("IsBuyableInScriptOnly", &SceneObject::IsBuyableInScriptOnly)
-		.def("IsBuyableInObjectPickerOnly", &SceneObject::IsBuyableInObjectPickerOnly)
 		.def("IsBuyableInBuyMenuOnly", &SceneObject::IsBuyableInBuyMenuOnly)
+		.def("IsBuyableInObjectPickerOnly", &SceneObject::IsBuyableInObjectPickerOnly)
+		.def("IsBuyableInScriptOnly", &SceneObject::IsBuyableInScriptOnly)
 		.def("IsOnScenePoint", &SceneObject::IsOnScenePoint)
 		.def("GetGoldValue", &SceneObject::GetGoldValueOld)
 		.def("GetGoldValue", &SceneObject::GetGoldValue)
@@ -1350,7 +1352,14 @@ namespace RTE {
 		.def("GetGoldValueString", &SceneObject::GetGoldValueString)
 		.def("GetTotalValue", &SceneObject::GetTotalValue)
 
-		.def("GetTotalValue", &LuaAdaptersSceneObject::GetTotalValue);
+		.def("GetTotalValue", &LuaAdaptersSceneObject::GetTotalValue)
+		
+		.enum_("BuyableMode")[
+			luabind::value("NORESTRICTIONS", SceneObject::BuyableMode::NoRestrictions),
+			luabind::value("BUYMENUONLY", SceneObject::BuyableMode::BuyMenuOnly),
+			luabind::value("OBJECTPICKERONLY", SceneObject::BuyableMode::ObjectPickerOnly),
+			luabind::value("SCRIPTONLY", SceneObject::BuyableMode::ScriptOnly)];
+		
 	}
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Lua/LuaBindingsEntities.cpp
+++ b/Lua/LuaBindingsEntities.cpp
@@ -371,6 +371,7 @@ namespace RTE {
 		.def("OpenDoor", &ADoor::OpenDoor)
 		.def("CloseDoor", &ADoor::CloseDoor)
 		.def("StopDoor", &ADoor::StopDoor)
+		.def("ResetSensorTimer", &ADoor::ResetSensorTimer)
 		.def("SetClosedByDefault", &ADoor::SetClosedByDefault)
 
 		.enum_("DoorState")[
@@ -1338,6 +1339,9 @@ namespace RTE {
 		.property("Team", &SceneObject::GetTeam, &SceneObject::SetTeam)
 		.property("PlacedByPlayer", &SceneObject::GetPlacedByPlayer, &SceneObject::SetPlacedByPlayer)
 		.property("IsBuyable", &SceneObject::IsBuyable)
+		.property("IsBuyableInScriptOnly", &SceneObject::IsBuyableInScriptOnly)
+		.property("IsBuyableInObjectPickerOnly", &SceneObject::IsBuyableInObjectPickerOnly)
+		.property("IsBuyableInBuyMenuOnly", &SceneObject::IsBuyableInBuyMenuOnly)
 
 		.def("IsOnScenePoint", &SceneObject::IsOnScenePoint)
 		.def("GetGoldValue", &SceneObject::GetGoldValueOld)

--- a/Lua/LuaBindingsEntities.cpp
+++ b/Lua/LuaBindingsEntities.cpp
@@ -1338,11 +1338,11 @@ namespace RTE {
 		.property("RotAngle", &SceneObject::GetRotAngle, &SceneObject::SetRotAngle)
 		.property("Team", &SceneObject::GetTeam, &SceneObject::SetTeam)
 		.property("PlacedByPlayer", &SceneObject::GetPlacedByPlayer, &SceneObject::SetPlacedByPlayer)
-		.property("IsBuyable", &SceneObject::IsBuyable)
-		.property("IsBuyableInScriptOnly", &SceneObject::IsBuyableInScriptOnly)
-		.property("IsBuyableInObjectPickerOnly", &SceneObject::IsBuyableInObjectPickerOnly)
-		.property("IsBuyableInBuyMenuOnly", &SceneObject::IsBuyableInBuyMenuOnly)
-
+		
+		.def("IsBuyable", &SceneObject::IsBuyable)
+		.def("IsBuyableInScriptOnly", &SceneObject::IsBuyableInScriptOnly)
+		.def("IsBuyableInObjectPickerOnly", &SceneObject::IsBuyableInObjectPickerOnly)
+		.def("IsBuyableInBuyMenuOnly", &SceneObject::IsBuyableInBuyMenuOnly)
 		.def("IsOnScenePoint", &SceneObject::IsOnScenePoint)
 		.def("GetGoldValue", &SceneObject::GetGoldValueOld)
 		.def("GetGoldValue", &SceneObject::GetGoldValue)

--- a/Lua/LuaBindingsEntities.cpp
+++ b/Lua/LuaBindingsEntities.cpp
@@ -1341,10 +1341,6 @@ namespace RTE {
 		.property("Buyable", &SceneObject::IsBuyable)
 		.property("BuyableMode", &SceneObject::GetBuyableMode)
 		
-		.def("IsBuyable", &SceneObject::IsBuyable)
-		.def("IsBuyableInBuyMenuOnly", &SceneObject::IsBuyableInBuyMenuOnly)
-		.def("IsBuyableInObjectPickerOnly", &SceneObject::IsBuyableInObjectPickerOnly)
-		.def("IsBuyableInScriptOnly", &SceneObject::IsBuyableInScriptOnly)
 		.def("IsOnScenePoint", &SceneObject::IsOnScenePoint)
 		.def("GetGoldValue", &SceneObject::GetGoldValueOld)
 		.def("GetGoldValue", &SceneObject::GetGoldValue)


### PR DESCRIPTION
very simple peep the changelog. BuyableMode is exposed, Buyable cleaned up a little, exposed ResetSensorTimer so doors can be cleanly indefinitely stopped via Lua (without having to expose sensors fully...)