### PR TITLE
Lua input functions

### DIFF
--- a/Activities/GameActivity.cpp
+++ b/Activities/GameActivity.cpp
@@ -400,14 +400,12 @@ bool GameActivity::IsBuyGUIVisible(int which) const {
 
 bool GameActivity::LockControlledActor(Players player, bool lock, Controller::InputMode lockToMode) {
 	if (player >= Players::PlayerOne && player < Players::MaxPlayerCount) {
+		bool prevLock = m_LuaLockActor[player];
 		m_LuaLockActor[player] = lock;
 		m_LuaLockActorMode[player] = lockToMode;
-		if (m_pBuyGUI[player]->IsVisible() || m_InventoryMenuGUI[player]->IsVisible()) {
-			m_LuaLockActor[player] = false;
-			return false;
-		}
 		return true;
 	}
+	return false;
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/Activities/GameActivity.cpp
+++ b/Activities/GameActivity.cpp
@@ -396,6 +396,20 @@ bool GameActivity::IsBuyGUIVisible(int which) const {
 
 }
 
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+bool GameActivity::LockControlledActor(Players player, bool lock, Controller::InputMode lockToMode) {
+	if (player >= Players::PlayerOne && player < Players::MaxPlayerCount) {
+		m_LuaLockActor[player] = lock;
+		m_LuaLockActorMode[player] = lockToMode;
+		if (m_pBuyGUI[player]->IsVisible() || m_InventoryMenuGUI[player]->IsVisible()) {
+			m_LuaLockActor[player] = false;
+			return false;
+		}
+		return true;
+	}
+}
+
 //////////////////////////////////////////////////////////////////////////////////////////
 // Virtual method:  SwitchToActor
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -1424,7 +1438,7 @@ void GameActivity::Update()
             m_ViewState[player] = ViewState::Normal;
         }
         // Switch to next actor if the player wants to. Don't do it while the buy menu is open
-        else if (m_PlayerController[player].IsState(ACTOR_NEXT) && m_ViewState[player] != ViewState::ActorSelect && !m_pBuyGUI[player]->IsVisible())
+        else if (m_PlayerController[player].IsState(ACTOR_NEXT) && m_ViewState[player] != ViewState::ActorSelect && !m_pBuyGUI[player]->IsVisible() && !m_LuaLockActor[player])
         {
 			if (m_ControlledActor[player] && m_ControlledActor[player]->GetPieMenu()) {
 				m_ControlledActor[player]->GetPieMenu()->SetEnabled(false);
@@ -1444,7 +1458,7 @@ void GameActivity::Update()
             g_FrameMan.ClearScreenText(ScreenOfPlayer(player));
         }
         // Go into manual actor select mode if either actor switch buttons are held for a duration
-        else if (m_ViewState[player] != ViewState::ActorSelect && !m_pBuyGUI[player]->IsVisible() && (m_PlayerController[player].IsState(ACTOR_NEXT_PREP) || m_PlayerController[player].IsState(ACTOR_PREV_PREP)))
+        else if (m_ViewState[player] != ViewState::ActorSelect && !m_pBuyGUI[player]->IsVisible() && !m_LuaLockActor[player] && (m_PlayerController[player].IsState(ACTOR_NEXT_PREP) || m_PlayerController[player].IsState(ACTOR_PREV_PREP)))
         {
             if (m_ActorSelectTimer[player].IsPastRealMS(250))
             {
@@ -2015,6 +2029,8 @@ void GameActivity::Update()
                 m_ControlledActor[player]->GetController()->SetInputMode(Controller::CIM_AI);
             } else if (m_InventoryMenuGUI[player]->IsEnabledAndNotCarousel()) {
                 m_ControlledActor[player]->GetController()->SetInputMode(Controller::CIM_DISABLED);
+            } else if (m_LuaLockActor[player]) {
+                m_ControlledActor[player]->GetController()->SetInputMode(m_LuaLockActorMode[player]);
             } else {
                 m_ControlledActor[player]->GetController()->SetInputMode(Controller::CIM_PLAYER);
             }

--- a/Activities/GameActivity.cpp
+++ b/Activities/GameActivity.cpp
@@ -1979,7 +1979,7 @@ void GameActivity::Update()
         }
 
         // Trap the mouse if we're in gameplay and not in menus
-		g_UInputMan.TrapMousePos(!m_pBuyGUI[player]->IsEnabled() && !m_InventoryMenuGUI[player]->IsEnabledAndNotCarousel(), player);
+		g_UInputMan.TrapMousePos(!m_pBuyGUI[player]->IsEnabled() && !m_InventoryMenuGUI[player]->IsEnabledAndNotCarousel() && !m_LuaLockActor[player], player);
 
         // Start LZ picking mode if a purchase was made
         if (m_pBuyGUI[player]->PurchaseMade())

--- a/Activities/GameActivity.h
+++ b/Activities/GameActivity.h
@@ -252,6 +252,16 @@ public:
 
     SceneEditorGUI * GetEditorGUI(unsigned int which = 0) const { return m_pEditorGUI[which]; }
 
+	/// <summary>
+	/// Locks a player controlled actor to a specific controller mode.
+	/// Locking the actor will disable player input, including switching actors.
+	/// Locking will fail if the actor is already locked for another reason (such as being in a menu).
+	/// </summary>
+	/// <param name="player">Which player to lock the actor for.</param>
+	/// <param name="lock">Whether to lock or unlock the actor. (Default: true)</param>
+	/// <param name="lockToMode">Which controller mode to lock the actor to. (Default: `CIM_AI`)</param>
+	/// <returns>Whether the (un)lock was performed.</returns>
+	bool LockControlledActor(Players player, bool lock = true, Controller::InputMode lockToMode = Controller::InputMode::CIM_AI);
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // Virtual method:  SwitchToActor
@@ -1035,6 +1045,8 @@ protected:
     BuyMenuGUI *m_pBuyGUI[Players::MaxPlayerCount];
     // The in-game scene editor GUI for each player
     SceneEditorGUI *m_pEditorGUI[Players::MaxPlayerCount];
+    bool m_LuaLockActor[Players::MaxPlayerCount]; //!< Whether or not to lock input for each player while lua has control.
+    Controller::InputMode m_LuaLockActorMode[Players::MaxPlayerCount]; //!< The input mode to lock to while lua has control.
     // The in-game important message banners for each player
     GUIBanner *m_pBannerRed[Players::MaxPlayerCount];
     GUIBanner *m_pBannerYellow[Players::MaxPlayerCount];

--- a/Activities/GameActivity.h
+++ b/Activities/GameActivity.h
@@ -255,7 +255,6 @@ public:
 	/// <summary>
 	/// Locks a player controlled actor to a specific controller mode.
 	/// Locking the actor will disable player input, including switching actors.
-	/// Locking will fail if the actor is already locked for another reason (such as being in a menu).
 	/// </summary>
 	/// <param name="player">Which player to lock the actor for.</param>
 	/// <param name="lock">Whether to lock or unlock the actor. (Default: true)</param>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - `Enum` binding for `SceneObject.BuyableMode`: `NORESTRICTIONS = 0, BUYMENUONLY = 1, OBJECTPICKERONLY = 2, SCRIPTONLY = 3`.  
 
+- Exposed `UInputMan::AbsoluteMousePos` to Lua
+
+- New `GameActivity::LockControlledActor` Lua function to allow grab player input in the way menus (buy menu/full inventorymenu) do.
+
 </details>
 
 <details><summary><b>Changed</b></summary>

--- a/Lua/LuaBindingsActivities.cpp
+++ b/Lua/LuaBindingsActivities.cpp
@@ -149,6 +149,7 @@ namespace RTE {
 		.def("SetActorSelectCursor", &GameActivity::SetActorSelectCursor)
 		.def("GetBuyGUI", &GameActivity::GetBuyGUI)
 		.def("GetEditorGUI", &GameActivity::GetEditorGUI)
+		.def("LockControlledActor", &GameActivity::LockControlledActor)
 		.def("OtherTeam", &GameActivity::OtherTeam)
 		.def("OneOrNoneTeamsLeft", &GameActivity::OneOrNoneTeamsLeft)
 		.def("WhichTeamLeft", &GameActivity::WhichTeamLeft)

--- a/Lua/LuaBindingsManagers.cpp
+++ b/Lua/LuaBindingsManagers.cpp
@@ -414,6 +414,7 @@ namespace RTE {
 		.def("MouseButtonPressed", &UInputMan::MouseButtonPressed)
 		.def("MouseButtonReleased", &UInputMan::MouseButtonReleased)
 		.def("MouseButtonHeld", &UInputMan::MouseButtonHeld)
+		.def("GetMousePos", &UInputMan::GetAbsoluteMousePosition)
 		.def("MouseWheelMoved", &UInputMan::MouseWheelMoved)
 		.def("JoyButtonPressed", &UInputMan::JoyButtonPressed)
 		.def("JoyButtonReleased", &UInputMan::JoyButtonReleased)


### PR DESCRIPTION
- Expose absolute mouse position to lua
- Allow grabbing player input while in GameActivity through `LockControlledActor(player,lock=true,lockToMode=CIM_AI)`


Limitations for GUI use:
- Cursor needs to be drawn manually
- The player controller needs to be manually grabbed when locking input